### PR TITLE
Add report template upload and AI image extraction for reports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ export default function App() {
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [lastSaved, setLastSaved] = useState<Date | undefined>();
   const [reportEntries, setReportEntries] = useState<{ timestamp: string; summary: string }[]>([]);
+  const [reportTemplate, setReportTemplate] = useState<string>('');
 
   // Auth listener
   useEffect(() => {
@@ -334,6 +335,18 @@ export default function App() {
       r.notes || '',
     ]);
 
+    const missingInventory = inventory
+      .filter(item => item.quantity <= item.minThreshold)
+      .map(item => `${item.name} (${item.quantity}${item.unit}, min ${item.minThreshold}${item.unit})`);
+    const missingEquipment = equipment
+      .filter(item => {
+        if (!item.lastServiceDate || !item.serviceIntervalMonths) return false;
+        const next = new Date(item.lastServiceDate);
+        next.setMonth(next.getMonth() + item.serviceIntervalMonths);
+        return new Date() >= next;
+      })
+      .map(item => item.name);
+
     const reportRows = reportEntries.map(entry => [
       entry.timestamp,
       '',
@@ -345,8 +358,15 @@ export default function App() {
       '',
       entry.summary
     ]);
+    const templateRows = reportTemplate
+      ? [[new Date().toISOString(), '', '', '', '', '', '', '', `Template: ${reportTemplate.replace(/\n+/g, ' ').trim()}`]]
+      : [];
+    const missingRows = [
+      [new Date().toISOString(), '', '', '', '', '', '', '', `Missing Inventory: ${missingInventory.length ? missingInventory.join('; ') : 'None'}`],
+      [new Date().toISOString(), '', '', '', '', '', '', '', `Missing Equipment Service: ${missingEquipment.length ? missingEquipment.join('; ') : 'None'}`]
+    ];
     
-    const csvContent = [headers, ...rows, ...reportRows].map(e => e.map(value => `"${String(value).replace(/"/g, '""')}"`).join(",")).join("\n");
+    const csvContent = [headers, ...rows, ...templateRows, ...missingRows, ...reportRows].map(e => e.map(value => `"${String(value).replace(/"/g, '""')}"`).join(",")).join("\n");
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement("a");
     const url = URL.createObjectURL(blob);
@@ -360,6 +380,17 @@ export default function App() {
 
   const handleAddToReport = (entry: { timestamp: string; summary: string }) => {
     setReportEntries(prev => [entry, ...prev].slice(0, 30));
+  };
+
+  const handleTemplateUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const content = typeof reader.result === 'string' ? reader.result : '';
+      setReportTemplate(content.slice(0, 5000));
+    };
+    reader.readAsText(file);
   };
 
   if (!isAuthReady) {
@@ -410,6 +441,10 @@ export default function App() {
           </h1>
         </div>
         <div className="flex items-center gap-3">
+          <label className="px-3 py-1.5 rounded-lg bg-surface border border-border-dim text-ink-dim hover:text-white transition-all text-[10px] font-bold uppercase tracking-widest cursor-pointer">
+            Report Template
+            <input type="file" accept=".txt,.md,.csv" onChange={handleTemplateUpload} className="hidden" />
+          </label>
           <button 
             onClick={() => setIsInventoryOpen(true)}
             className="p-2 rounded-lg bg-surface border border-border-dim text-ink-muted hover:text-white transition-colors"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -383,12 +383,17 @@ export default function App() {
   };
 
   const handleTemplateUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+    const input = e.target;
+    const file = input.files?.[0];
     if (!file) return;
     const reader = new FileReader();
     reader.onload = () => {
       const content = typeof reader.result === 'string' ? reader.result : '';
       setReportTemplate(content.slice(0, 5000));
+      input.value = '';
+    };
+    reader.onerror = () => {
+      input.value = '';
     };
     reader.readAsText(file);
   };

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -47,6 +47,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [isTranscribingNotes, setIsTranscribingNotes] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isAnalyzingImage, setIsAnalyzingImage] = useState(false);
   const [rawInputs, setRawInputs] = useState<Record<string, string>>(
     () => Object.fromEntries(NUMERIC_FIELDS.map(f => [f, String(INITIAL_NUMERIC[f])]))
   );
@@ -182,6 +183,61 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
     }
   };
 
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setIsAnalyzingImage(true);
+    try {
+      const dataUrl = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+      const base64 = dataUrl.split(',')[1];
+      const response = await generateContentWithRetry({
+        model: "gemini-3-flash-preview",
+        contents: [
+          {
+            inlineData: {
+              mimeType: file.type || 'image/jpeg',
+              data: base64
+            }
+          },
+          {
+            text: `Extract pool report details from this image. Return ONLY a JSON object with keys:
+chlorine, ph, alkalinity, temperature, differentialPressure, calciumHardness, cyanuricAcid, notes, missingInventory, missingEquipment.
+missingInventory and missingEquipment should be arrays of strings when identifiable.`
+          }
+        ],
+        config: { responseMimeType: "application/json" }
+      }, process.env.GEMINI_API_KEY!);
+      const parsed = JSON.parse(response.text || '{}');
+      const noteParts = [
+        parsed.notes,
+        parsed.missingInventory?.length ? `Missing Inventory: ${parsed.missingInventory.join(', ')}` : '',
+        parsed.missingEquipment?.length ? `Missing Equipment: ${parsed.missingEquipment.join(', ')}` : ''
+      ].filter(Boolean);
+      setFormData(prev => ({
+        ...prev,
+        ...parsed,
+        notes: noteParts.length ? `${prev.notes ? `${prev.notes}\n` : ''}${noteParts.join('\n')}` : prev.notes
+      }));
+      setRawInputs(prev => {
+        const updates: Record<string, string> = {};
+        for (const field of NUMERIC_FIELDS) {
+          if (parsed[field] !== undefined && parsed[field] !== null) updates[field] = String(parsed[field]);
+        }
+        return { ...prev, ...updates };
+      });
+    } catch (error) {
+      console.error('Image analysis failed', error);
+    } finally {
+      setIsAnalyzingImage(false);
+      e.target.value = '';
+    }
+  };
+
   return (
     <motion.div 
       initial={{ opacity: 0, scale: 0.95 }}
@@ -314,6 +370,13 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
             <p className="text-[9px] text-ink-dim italic">
               {isTranscribing ? 'Listening for readings...' : 'Speak your readings (e.g., "Chlorine 1.5, pH 7.4")'}
             </p>
+          </div>
+          <div className="flex items-center justify-between p-4 bg-bg/40 rounded-xl border border-border-dim">
+            <p className="text-[9px] text-ink-dim italic">Upload a photo of a report sheet/equipment room and auto-extract values.</p>
+            <label className={`px-4 py-2 rounded-lg text-[10px] font-bold uppercase tracking-widest cursor-pointer transition-all ${isAnalyzingImage ? 'bg-critical text-white' : 'bg-accent/10 text-accent hover:bg-accent/20'}`}>
+              {isAnalyzingImage ? 'Analyzing…' : 'Upload Image'}
+              <input type="file" accept="image/*" onChange={handleImageUpload} className="hidden" disabled={isAnalyzingImage} />
+            </label>
           </div>
 
           <div className="space-y-3">


### PR DESCRIPTION
### Motivation
- Allow users to upload a report template to include in exported reports.
- Surface missing inventory and equipment service needs directly in exported reports so reports reflect gaps in stock/maintenance.
- Let users upload a photo of a report sheet or equipment area and have the AI extract readings and identify missing items to auto-populate the report.

### Description
- Add `reportTemplate` app state, a top-nav file input (`.txt/.md/.csv`) and `handleTemplateUpload` to read and persist template text for export.
- Extend `exportToCSV` to include uploaded template context and computed rows for `Missing Inventory` (items at/below `minThreshold`) and `Missing Equipment Service` (items overdue based on `lastServiceDate` + `serviceIntervalMonths`).
- Add image upload UI and `handleImageUpload` in `ReadingForm` which sends the image (Base64) to the existing `generateContentWithRetry`/Gemini helper expecting JSON, then populates numeric fields, `rawInputs`, and appends detected `missingInventory`/`missingEquipment` into `notes`.
- Add small UI state `isAnalyzingImage` and guard/formatting logic (template truncated to 5000 chars) to keep the feature lightweight.

### Testing
- Ran the TypeScript linter via `npm run lint` (which executes `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f285b2afbc832eaef830e185284dfc)