### PR TITLE
Add general pool Q&A workflow and relax reading form validation

### DIFF
--- a/src/components/GeminiAssistant.tsx
+++ b/src/components/GeminiAssistant.tsx
@@ -158,6 +158,7 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
   const [mapsContent, setMapsContent] = useState<string | null>(null);
   const [protocolStaged, setProtocolStaged] = useState(false);
   const [addedToReport, setAddedToReport] = useState(false);
+  const [question, setQuestion] = useState('');
 
   const getInsight = async () => {
     if (!latestReading) return;
@@ -342,6 +343,38 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
     }
   };
 
+  const askGeneralQuestion = async () => {
+    if (!question.trim()) return;
+    setIsOpen(true);
+    setLoading(true);
+    setError(null);
+    setIsMapsMode(false);
+
+    try {
+      const context = latestReading
+        ? `Latest reading context: FC ${latestReading.chlorine} ppm, pH ${latestReading.ph}, TA ${latestReading.alkalinity} ppm, Temp ${latestReading.temperature}°C, CYA ${latestReading.cyanuricAcid} ppm.`
+        : 'No latest reading is currently available.';
+      const response = await callAiWithFallback({
+        model: "gemini-3-flash-preview",
+        contents: `${context}\n\nUser question: ${question.trim()}\n\nProvide a direct practical answer. If diagnostics are needed, include specific checks in order.`,
+        config: {
+          systemInstruction: POOL_SYSTEM_PROMPT,
+        }
+      }, process.env.GEMINI_API_KEY!);
+
+      setInsight({
+        analysis: response.text || 'No response generated.',
+        checklist: [],
+        expectedOutcome: 'N/A',
+      });
+    } catch (err) {
+      console.error('General QA Error:', err);
+      setError('ERR_QUESTION_FAILED: Unable to answer your question right now.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <>
       <button 
@@ -374,6 +407,22 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
               </header>
               
               <div className="p-6 max-h-[60vh] overflow-y-auto custom-scrollbar">
+                <div className="mb-5 p-4 rounded-xl border border-border-dim bg-[#08162a] space-y-3">
+                  <label className="block text-[10px] font-bold uppercase tracking-widest text-ink-dim">Ask a general pool question</label>
+                  <textarea
+                    value={question}
+                    onChange={(e) => setQuestion(e.target.value)}
+                    placeholder="e.g. Why does pH keep rising even after adding acid?"
+                    className="input bg-[#0d1f38] border-border-dim min-h-[78px] resize-none py-3 text-sm"
+                  />
+                  <button
+                    onClick={askGeneralQuestion}
+                    disabled={loading || !question.trim()}
+                    className="w-full py-2.5 px-4 rounded-lg bg-accent text-primary text-[10px] font-bold uppercase tracking-widest disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Ask Pool AI
+                  </button>
+                </div>
                 {loading ? (
                   <div className="flex flex-col items-center justify-center py-16 space-y-6">
                     <div className="relative">
@@ -404,24 +453,30 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
 
                     <section>
                       <h3 className="text-[10px] font-bold uppercase tracking-widest text-accent mb-3">Suggested Checklist</h3>
-                      <div className="space-y-2">
-                        {insight.checklist.map((item, idx) => (
-                          <div key={item.id} className="flex items-start gap-3 p-3 bg-surface rounded-xl border border-border-dim/50">
-                            <span className="flex-shrink-0 w-5 h-5 rounded-full bg-accent/10 text-accent text-[10px] font-bold flex items-center justify-center border border-accent/20">
-                              {idx + 1}
-                            </span>
-                            <span className="text-sm text-ink">{item.title}</span>
-                          </div>
-                        ))}
-                      </div>
+                      {insight.checklist.length > 0 ? (
+                        <div className="space-y-2">
+                          {insight.checklist.map((item, idx) => (
+                            <div key={item.id} className="flex items-start gap-3 p-3 bg-surface rounded-xl border border-border-dim/50">
+                              <span className="flex-shrink-0 w-5 h-5 rounded-full bg-accent/10 text-accent text-[10px] font-bold flex items-center justify-center border border-accent/20">
+                                {idx + 1}
+                              </span>
+                              <span className="text-sm text-ink">{item.title}</span>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-xs text-ink-dim">No action checklist generated for this response.</p>
+                      )}
                     </section>
 
-                    <section className="p-4 bg-accent/5 rounded-xl border border-accent/10">
-                      <h3 className="text-[10px] font-bold uppercase tracking-widest text-accent mb-2">Target Telemetry (Post-Protocol)</h3>
-                      <div className="markdown-body text-ink-muted text-xs leading-relaxed font-sans italic">
-                        <ReactMarkdown>{insight.expectedOutcome}</ReactMarkdown>
-                      </div>
-                    </section>
+                    {insight.expectedOutcome !== 'N/A' && (
+                      <section className="p-4 bg-accent/5 rounded-xl border border-accent/10">
+                        <h3 className="text-[10px] font-bold uppercase tracking-widest text-accent mb-2">Target Telemetry (Post-Protocol)</h3>
+                        <div className="markdown-body text-ink-muted text-xs leading-relaxed font-sans italic">
+                          <ReactMarkdown>{insight.expectedOutcome}</ReactMarkdown>
+                        </div>
+                      </section>
+                    )}
                   </div>
                 ) : null}
               </div>

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -204,7 +204,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
           </div>
         </header>
 
-        <form onSubmit={handleSubmit} className="space-y-10 pb-32">
+        <form onSubmit={handleSubmit} noValidate className="space-y-10 pb-32">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             <InputField
               label="Free Chlorine"


### PR DESCRIPTION
### Motivation

- Provide operators a simple place to ask general, open-ended pool chemistry or troubleshooting questions (e.g., persistent pH drift) without forcing a telemetry-only analysis flow.
- Allow legitimate readings that fall outside recommended ranges (e.g., out-of-range temperature) to be recorded in the database while still surfacing an out-of-range UI state.

### Description

- Added a general question UI to the AI panel with a new `question` state, textarea, and `Ask Pool AI` button that triggers a new `askGeneralQuestion` flow in `src/components/GeminiAssistant.tsx`.
- Implemented `askGeneralQuestion` to send the user question plus optional `latestReading` context to the existing AI backend via `callAiWithFallback` using the existing `POOL_SYSTEM_PROMPT` and render the response as the assistant's analysis.
- Made AI result rendering resilient to non-protocol answers by handling empty `checklist` arrays and conditionally hiding the target-telemetry section when `expectedOutcome` is `'N/A'`.
- Disabled browser native form constraint blocking on the reading form by adding `noValidate` to the `<form>` in `src/components/ReadingForm.tsx` so out-of-optimal-range numeric inputs can still be saved while preserving ranged UI validation messages.

### Testing

- Ran the project's typecheck/linter with `npm run lint` (which runs `tsc --noEmit`), and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b60e0ff8832ebeef4ca72a36a622)