### PR TITLE
Add WorkSession tracker with Joy Lane geolocation and history visit summaries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -255,9 +255,14 @@ export default function App() {
 
   const handleStopWorkSession = async () => {
     if (!activeSession) return;
-    await updateDoc(doc(db, 'workSessions', activeSession.id), {
-      endTime: Timestamp.fromDate(new Date())
-    });
+
+    try {
+      await updateDoc(doc(db, 'workSessions', activeSession.id), {
+        endTime: Timestamp.fromDate(new Date())
+      });
+    } catch (err) {
+      handleFirestoreError(err, OperationType.WRITE, `workSessions/${activeSession.id}`);
+    }
   };
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,12 +178,15 @@ export default function App() {
     }, (err) => handleFirestoreError(err, OperationType.LIST, 'wishlist'));
 
 
-    const unsubSessions = onSnapshot(sessionsQuery, (snapshot) => {
       setWorkSessions(snapshot.docs.map((sessionDoc) => {
         const data = sessionDoc.data();
         return {
           ...data,
           id: sessionDoc.id,
+          startTime: (data.startTime as Timestamp).toDate(),
+          endTime: data.endTime ? (data.endTime as Timestamp).toDate() : null,
+        } as WorkSession;
+      }));
           startTime: (data.startTime as Timestamp).toDate(),
           endTime: data.endTime ? (data.endTime as Timestamp).toDate() : null,
         } as WorkSession;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import Dashboard from './components/Dashboard';
 import ReadingForm from './components/ReadingForm';
@@ -51,6 +51,7 @@ export default function App() {
   const [lastSaved, setLastSaved] = useState<Date | undefined>();
   const [reportEntries, setReportEntries] = useState<{ timestamp: string; summary: string }[]>([]);
   const [reportTemplate, setReportTemplate] = useState<string>('');
+  const geoStartInFlight = useRef(false);
 
   // Auth listener
   useEffect(() => {
@@ -178,12 +179,15 @@ export default function App() {
 
 
     const unsubSessions = onSnapshot(sessionsQuery, (snapshot) => {
-      setWorkSessions(snapshot.docs.map((sessionDoc) => ({
-        ...sessionDoc.data(),
-        id: sessionDoc.id,
-        startTime: (sessionDoc.data().startTime as Timestamp).toDate(),
-        endTime: sessionDoc.data().endTime ? (sessionDoc.data().endTime as Timestamp).toDate() : null,
-      } as WorkSession)));
+      setWorkSessions(snapshot.docs.map((sessionDoc) => {
+        const data = sessionDoc.data();
+        return {
+          ...data,
+          id: sessionDoc.id,
+          startTime: (data.startTime as Timestamp).toDate(),
+          endTime: data.endTime ? (data.endTime as Timestamp).toDate() : null,
+        } as WorkSession;
+      }));
     }, (err) => handleFirestoreError(err, OperationType.LIST, 'workSessions'));
 
     const unsubSchedule = onSnapshot(scheduleDoc, (doc) => {
@@ -249,7 +253,7 @@ export default function App() {
         locationLabel: source === 'geo' ? 'Joy Lane' : 'Manual start',
       });
     } catch (error) {
-      handleFirestoreError(error, OperationType.CREATE);
+      handleFirestoreError(error, OperationType.CREATE, 'workSessions');
     }
   };
 
@@ -274,8 +278,12 @@ export default function App() {
       const dLon = toRad(position.coords.longitude - joyLane.longitude);
       const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(joyLane.latitude)) * Math.cos(toRad(position.coords.latitude)) * Math.sin(dLon / 2) ** 2;
       const meters = 6371000 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-      if (meters < 120) {
-        void handleStartWorkSession('geo');
+      if (meters < 120 && !geoStartInFlight.current) {
+        geoStartInFlight.current = true;
+        navigator.geolocation.clearWatch(watchId);
+        handleStartWorkSession('geo').finally(() => {
+          geoStartInFlight.current = false;
+        });
       }
     });
     return () => navigator.geolocation.clearWatch(watchId);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,15 +178,12 @@ export default function App() {
     }, (err) => handleFirestoreError(err, OperationType.LIST, 'wishlist'));
 
 
+    const unsubSessions = onSnapshot(sessionsQuery, (snapshot) => {
       setWorkSessions(snapshot.docs.map((sessionDoc) => {
         const data = sessionDoc.data();
         return {
           ...data,
           id: sessionDoc.id,
-          startTime: (data.startTime as Timestamp).toDate(),
-          endTime: data.endTime ? (data.endTime as Timestamp).toDate() : null,
-        } as WorkSession;
-      }));
           startTime: (data.startTime as Timestamp).toDate(),
           endTime: data.endTime ? (data.endTime as Timestamp).toDate() : null,
         } as WorkSession;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -240,13 +240,17 @@ export default function App() {
 
   const handleStartWorkSession = async (source: 'manual' | 'geo') => {
     if (!user || activeSession) return;
-    await addDoc(collection(db, 'workSessions'), {
-      uid: user.uid,
-      startTime: Timestamp.fromDate(new Date()),
-      endTime: null,
-      source,
-      locationLabel: source === 'geo' ? 'Joy Lane' : 'Manual start',
-    });
+    try {
+      await addDoc(collection(db, 'workSessions'), {
+        uid: user.uid,
+        startTime: Timestamp.fromDate(new Date()),
+        endTime: null,
+        source,
+        locationLabel: source === 'geo' ? 'Joy Lane' : 'Manual start',
+      });
+    } catch (error) {
+      handleFirestoreError(error, OperationType.CREATE);
+    }
   };
 
   const handleStopWorkSession = async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ import Inventory from './components/Inventory';
 import Equipment from './components/Equipment';
 import Wishlist from './components/Wishlist';
 import WeeklyReport from './components/WeeklyReport';
-import { Reading, MaintenanceTask, MaintenanceSchedule, Frequency, InventoryItem, EquipmentItem, WishlistItem } from './types';
+import WorkTracker from './components/WorkTracker';
+import { Reading, MaintenanceTask, MaintenanceSchedule, Frequency, InventoryItem, EquipmentItem, WishlistItem, WorkSession } from './types';
 import { auth, db, signIn, logout, handleFirestoreError, OperationType } from './firebase';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { collection, query, where, onSnapshot, doc, setDoc, updateDoc, deleteDoc, Timestamp, orderBy, getDoc, addDoc } from 'firebase/firestore';
@@ -27,6 +28,8 @@ export default function App() {
   const [inventory, setInventory] = useState<InventoryItem[]>([]);
   const [equipment, setEquipment] = useState<EquipmentItem[]>([]);
   const [wishlist, setWishlist] = useState<WishlistItem[]>([]);
+  const [workSessions, setWorkSessions] = useState<WorkSession[]>([]);
+  const [geoAutoStartEnabled, setGeoAutoStartEnabled] = useState(false);
   const [schedule, setSchedule] = useState<MaintenanceSchedule>({
     uid: '',
     testFrequency: 'weekly',
@@ -66,6 +69,7 @@ export default function App() {
       setInventory([]);
       setEquipment([]);
       setWishlist([]);
+      setWorkSessions([]);
       return;
     }
 
@@ -74,6 +78,7 @@ export default function App() {
     const inventoryQuery = query(collection(db, 'inventory'), where('uid', '==', user.uid));
     const equipmentQuery = query(collection(db, 'equipment'), where('uid', '==', user.uid));
     const wishlistQuery = query(collection(db, 'wishlist'), where('uid', '==', user.uid));
+    const sessionsQuery = query(collection(db, 'workSessions'), where('uid', '==', user.uid), orderBy('startTime', 'desc'));
     const scheduleDoc = doc(db, 'schedules', user.uid);
 
     const unsubReadings = onSnapshot(readingsQuery, (snapshot) => {
@@ -171,6 +176,16 @@ export default function App() {
       setWishlist(items);
     }, (err) => handleFirestoreError(err, OperationType.LIST, 'wishlist'));
 
+
+    const unsubSessions = onSnapshot(sessionsQuery, (snapshot) => {
+      setWorkSessions(snapshot.docs.map((sessionDoc) => ({
+        ...sessionDoc.data(),
+        id: sessionDoc.id,
+        startTime: (sessionDoc.data().startTime as Timestamp).toDate(),
+        endTime: sessionDoc.data().endTime ? (sessionDoc.data().endTime as Timestamp).toDate() : null,
+      } as WorkSession)));
+    }, (err) => handleFirestoreError(err, OperationType.LIST, 'workSessions'));
+
     const unsubSchedule = onSnapshot(scheduleDoc, (doc) => {
       if (doc.exists()) {
         const data = doc.data();
@@ -188,6 +203,7 @@ export default function App() {
       unsubInventory();
       unsubEquipment();
       unsubWishlist();
+      unsubSessions();
       unsubSchedule();
     };
   }, [user]);
@@ -218,6 +234,43 @@ export default function App() {
       }
     }
   }, [schedule]);
+
+
+  const activeSession = workSessions.find((session) => !session.endTime) || null;
+
+  const handleStartWorkSession = async (source: 'manual' | 'geo') => {
+    if (!user || activeSession) return;
+    await addDoc(collection(db, 'workSessions'), {
+      uid: user.uid,
+      startTime: Timestamp.fromDate(new Date()),
+      endTime: null,
+      source,
+      locationLabel: source === 'geo' ? 'Joy Lane' : 'Manual start',
+    });
+  };
+
+  const handleStopWorkSession = async () => {
+    if (!activeSession) return;
+    await updateDoc(doc(db, 'workSessions', activeSession.id), {
+      endTime: Timestamp.fromDate(new Date())
+    });
+  };
+
+  useEffect(() => {
+    if (!geoAutoStartEnabled || !user || activeSession || !('geolocation' in navigator)) return;
+    const joyLane = { latitude: 30.266, longitude: -97.743 };
+    const watchId = navigator.geolocation.watchPosition((position) => {
+      const toRad = (v: number) => (v * Math.PI) / 180;
+      const dLat = toRad(position.coords.latitude - joyLane.latitude);
+      const dLon = toRad(position.coords.longitude - joyLane.longitude);
+      const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(joyLane.latitude)) * Math.cos(toRad(position.coords.latitude)) * Math.sin(dLon / 2) ** 2;
+      const meters = 6371000 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+      if (meters < 120) {
+        void handleStartWorkSession('geo');
+      }
+    });
+    return () => navigator.geolocation.clearWatch(watchId);
+  }, [geoAutoStartEnabled, user, activeSession]);
 
   const handleSaveReading = async (newReading: Omit<Reading, 'id' | 'timestamp' | 'uid'>) => {
     if (!user) return;
@@ -570,7 +623,15 @@ export default function App() {
         </div>
       </nav>
 
-      <main className="max-w-4xl mx-auto px-4 pt-24 pb-24 md:pt-28 grid-bg">
+      <main className="max-w-4xl mx-auto px-4 pt-24 pb-24 md:pt-28 grid-bg space-y-4">
+        <WorkTracker
+          sessions={workSessions}
+          activeSession={activeSession}
+          geoAutoStartEnabled={geoAutoStartEnabled}
+          onStart={handleStartWorkSession}
+          onStop={handleStopWorkSession}
+          onToggleGeoAutoStart={setGeoAutoStartEnabled}
+        />
         <Dashboard 
           readings={readings} 
           tasks={tasks}

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -11,6 +11,10 @@ interface Props {
 }
 
 export default function History({ readings, onBack, onDelete }: Props) {
+
+  const uniqueVisitDays = new Set(readings.map((reading) => format(reading.timestamp, 'yyyy-MM-dd'))).size;
+  const firstVisit = readings.length ? readings[readings.length - 1].timestamp : null;
+  const lastVisit = readings.length ? readings[0].timestamp : null;
   return (
     <motion.div 
       initial={{ opacity: 0, x: 20 }}
@@ -32,6 +36,12 @@ export default function History({ readings, onBack, onDelete }: Props) {
             <p className="text-[9px] font-bold uppercase tracking-widest text-ink-dim">Historical Data Archive</p>
           </div>
         </header>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div className="card bg-surface border-border-dim p-4"><p className="text-[10px] uppercase tracking-widest text-ink-dim">Logged Visits</p><p className="text-2xl font-bold text-white">{uniqueVisitDays}</p></div>
+          <div className="card bg-surface border-border-dim p-4"><p className="text-[10px] uppercase tracking-widest text-ink-dim">Total Logs</p><p className="text-2xl font-bold text-white">{readings.length}</p></div>
+          <div className="card bg-surface border-border-dim p-4"><p className="text-[10px] uppercase tracking-widest text-ink-dim">Range</p><p className="text-xs font-mono text-ink-muted">{firstVisit ? format(firstVisit, 'MMM d, yyyy') : '—'} → {lastVisit ? format(lastVisit, 'MMM d, yyyy') : '—'}</p></div>
+        </div>
 
         <div className="space-y-4">
           {readings.length === 0 ? (

--- a/src/components/WorkTracker.tsx
+++ b/src/components/WorkTracker.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { MapPin, Play, Square, Timer } from 'lucide-react';
+import { WorkSession } from '../types';
+
+interface Props {
+  sessions: WorkSession[];
+  activeSession: WorkSession | null;
+  geoAutoStartEnabled: boolean;
+  onStart: (source: 'manual' | 'geo') => void;
+  onStop: () => void;
+  onToggleGeoAutoStart: (enabled: boolean) => void;
+}
+
+const formatDuration = (ms: number) => {
+  const totalMinutes = Math.max(0, Math.floor(ms / 60000));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+};
+
+export default function WorkTracker({ sessions, activeSession, geoAutoStartEnabled, onStart, onStop, onToggleGeoAutoStart }: Props) {
+  const totalMs = sessions.reduce((acc, session) => {
+    const end = session.endTime ? session.endTime.getTime() : Date.now();
+    return acc + Math.max(0, end - session.startTime.getTime());
+  }, 0);
+
+  const poolDays = new Set(sessions.map(s => s.startTime.toISOString().slice(0, 10))).size;
+
+  return (
+    <section className="card bg-surface border-border-dim p-4 space-y-4">
+      <header className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-bold text-ink">Work Time Tracker</h3>
+          <p className="text-[10px] uppercase tracking-widest text-ink-dim">Joy Lane billing helper</p>
+        </div>
+        <Timer size={16} className="text-accent" />
+      </header>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg border border-border-dim p-3">
+          <p className="text-[10px] text-ink-dim uppercase tracking-widest">Pool Days</p>
+          <p className="text-xl font-bold text-white">{poolDays}</p>
+        </div>
+        <div className="rounded-lg border border-border-dim p-3">
+          <p className="text-[10px] text-ink-dim uppercase tracking-widest">Total Logged</p>
+          <p className="text-xl font-bold text-white">{formatDuration(totalMs)}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {!activeSession ? (
+          <button onClick={() => onStart('manual')} className="flex items-center gap-2 rounded-lg bg-accent text-primary px-3 py-2 text-xs font-bold uppercase tracking-widest">
+            <Play size={14} /> Start Session
+          </button>
+        ) : (
+          <button onClick={onStop} className="flex items-center gap-2 rounded-lg bg-critical/20 text-critical px-3 py-2 text-xs font-bold uppercase tracking-widest border border-critical/40">
+            <Square size={14} /> Stop Session
+          </button>
+        )}
+
+        <label className="flex items-center gap-2 text-xs text-ink-muted">
+          <input type="checkbox" checked={geoAutoStartEnabled} onChange={(e) => onToggleGeoAutoStart(e.target.checked)} />
+          Auto-start at Joy Lane
+          <MapPin size={12} />
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/src/components/WorkTracker.tsx
+++ b/src/components/WorkTracker.tsx
@@ -18,13 +18,20 @@ const formatDuration = (ms: number) => {
   return `${hours}h ${minutes}m`;
 };
 
+const getLocalDayKey = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
 export default function WorkTracker({ sessions, activeSession, geoAutoStartEnabled, onStart, onStop, onToggleGeoAutoStart }: Props) {
   const totalMs = sessions.reduce((acc, session) => {
     const end = session.endTime ? session.endTime.getTime() : Date.now();
     return acc + Math.max(0, end - session.startTime.getTime());
   }, 0);
 
-  const poolDays = new Set(sessions.map(s => s.startTime.toISOString().slice(0, 10))).size;
+  const poolDays = new Set(sessions.map(s => getLocalDayKey(s.startTime))).size;
 
   return (
     <section className="card bg-surface border-border-dim p-4 space-y-4">

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,15 @@ export interface MaintenanceSchedule {
   remindersEnabled: boolean;
 }
 
+export interface WorkSession {
+  id: string;
+  uid: string;
+  startTime: Date;
+  endTime: Date | null;
+  source: 'manual' | 'geo';
+  locationLabel?: string;
+}
+
 export interface Ranges {
   chlorine: { min: number; max: number; unit: string };
   ph: { min: number; max: number; unit: string };


### PR DESCRIPTION
### Motivation

- Provide a simple way to bill time spent at the pool by recording start/stop work sessions and summarizing visit frequency from existing logs.
- Support auto-starting sessions when the user is geolocated at the Joy Lane area to reduce manual overhead.

### Description

- Added a new `WorkSession` type to `src/types.ts` to represent start/end timestamps, `uid`, `source` (`manual` | `geo`), and optional `locationLabel`.
- Implemented `WorkTracker` UI in `src/components/WorkTracker.tsx` that shows `Pool Days`, total logged duration, a `Start Session` / `Stop Session` control, and an `Auto-start at Joy Lane` toggle.
- Wired Firestore-backed session sync in `src/App.tsx` with a `workSessions` query, subscription (`onSnapshot`), create (`addDoc`) and update (`updateDoc`) handlers, an `activeSession` helper, and a geolocation watcher that auto-starts a session when within ~120m of the configured Joy Lane coordinates.
- Enhanced the history view in `src/components/History.tsx` with summary cards that compute unique logged visit days, total logs, and first-to-last log date range from existing telemetry readings.

### Testing

- Ran the TypeScript lint/compile check via `npm run lint` (which executes `tsc --noEmit`) and it completed successfully.
- No automated unit tests were added; static type checks were used to validate the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa23cde254832e95b75decd3712942)