### PR TITLE
Carry forward last reading's values for untouched form fields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -622,9 +622,10 @@ export default function App() {
 
       <AnimatePresence>
         {isLogging && (
-          <ReadingForm 
+          <ReadingForm
             onSave={handleSaveReading}
             onCancel={() => setIsLogging(false)}
+            latestReading={readings[0]}
           />
         )}
         

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { History as HistoryIcon } from 'lucide-react';
 import {
   Check,
   AlertCircle,
@@ -23,6 +24,7 @@ import { generateContentWithRetry } from '../lib/gemini';
 interface Props {
   onSave: (reading: Omit<Reading, 'id' | 'timestamp'>) => void;
   onCancel: () => void;
+  latestReading?: Reading;
 }
 
 const NUMERIC_FIELDS = ['chlorine', 'ph', 'alkalinity', 'temperature', 'differentialPressure', 'calciumHardness', 'cyanuricAcid'] as const;
@@ -38,7 +40,7 @@ const FIELD_LABELS: Record<NumericField, string> = {
   cyanuricAcid: 'Cyanuric Acid',
 };
 
-const INITIAL_NUMERIC: Record<NumericField, number> = {
+const FALLBACK_NUMERIC: Record<NumericField, number> = {
   chlorine: 1.5,
   ph: 7.4,
   alkalinity: 100,
@@ -48,9 +50,21 @@ const INITIAL_NUMERIC: Record<NumericField, number> = {
   cyanuricAcid: 40,
 };
 
-export default function ReadingForm({ onSave, onCancel }: Props) {
+export default function ReadingForm({ onSave, onCancel, latestReading }: Props) {
+  // Prefill from the most recent reading when available; fall back to typical values otherwise.
+  const initialNumeric = React.useMemo<Record<NumericField, number>>(() => {
+    if (!latestReading) return { ...FALLBACK_NUMERIC };
+    const out = { ...FALLBACK_NUMERIC };
+    for (const field of NUMERIC_FIELDS) {
+      const v = latestReading[field];
+      if (typeof v === 'number' && isFinite(v)) out[field] = v;
+    }
+    return out;
+  }, [latestReading]);
+  const carriedFromHistory = !!latestReading;
+
   const [formData, setFormData] = useState({
-    ...INITIAL_NUMERIC,
+    ...initialNumeric,
     notes: '',
     uid: '',
   });
@@ -63,7 +77,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
   const [showDefaultsWarning, setShowDefaultsWarning] = useState(false);
   const [isAnalyzingImage, setIsAnalyzingImage] = useState(false);
   const [rawInputs, setRawInputs] = useState<Record<string, string>>(
-    () => Object.fromEntries(NUMERIC_FIELDS.map(f => [f, String(INITIAL_NUMERIC[f])]))
+    () => Object.fromEntries(NUMERIC_FIELDS.map(f => [f, String(initialNumeric[f])]))
   );
 
   const validate = (name: string, value: number) => {
@@ -309,6 +323,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={10}
               step="any"
               isDefault={!touched.has('chlorine')}
+              carried={carriedFromHistory}
             />
             <InputField
               label="pH Level"
@@ -323,6 +338,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={14}
               step="any"
               isDefault={!touched.has('ph')}
+              carried={carriedFromHistory}
             />
             <InputField
               label="Total Alkalinity"
@@ -337,6 +353,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={300}
               step="any"
               isDefault={!touched.has('alkalinity')}
+              carried={carriedFromHistory}
             />
             <InputField
               label="Temperature"
@@ -351,6 +368,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={50}
               step="any"
               isDefault={!touched.has('temperature')}
+              carried={carriedFromHistory}
             />
             <InputField
               label="Diff Pressure"
@@ -365,6 +383,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={500}
               step="any"
               isDefault={!touched.has('differentialPressure')}
+              carried={carriedFromHistory}
             />
             <InputField
               label="Calcium Hardness"
@@ -379,6 +398,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={1000}
               step="any"
               isDefault={!touched.has('calciumHardness')}
+              carried={carriedFromHistory}
             />
             <InputField
               label="Cyanuric Acid"
@@ -393,6 +413,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={200}
               step="any"
               isDefault={!touched.has('cyanuricAcid')}
+              carried={carriedFromHistory}
             />
           </div>
 
@@ -455,10 +476,12 @@ missingInventory and missingEquipment should be arrays of strings when identifia
                   <div className="p-4 rounded-xl bg-warning/10 border border-warning/40">
                     <div className="flex items-center gap-2 mb-2">
                       <AlertCircle size={14} className="text-warning flex-shrink-0" />
-                      <span className="text-[10px] font-bold uppercase tracking-widest text-warning">Unsaved field defaults detected</span>
+                      <span className="text-[10px] font-bold uppercase tracking-widest text-warning">
+                        {carriedFromHistory ? 'Some fields carried over' : 'Unsaved field defaults detected'}
+                      </span>
                     </div>
                     <p className="text-xs text-ink-muted mb-3">
-                      <strong className="text-ink">{untouched.map(f => FIELD_LABELS[f]).join(', ')}</strong> {untouched.length === 1 ? 'was' : 'were'} not entered — the pre-filled estimate{untouched.length === 1 ? '' : 's'} will be saved and may affect report accuracy.
+                      <strong className="text-ink">{untouched.map(f => FIELD_LABELS[f]).join(', ')}</strong> {untouched.length === 1 ? 'was' : 'were'} not entered — {carriedFromHistory ? `${untouched.length === 1 ? 'the value' : 'values'} from your last reading will be saved.` : `the pre-filled estimate${untouched.length === 1 ? '' : 's'} will be saved and may affect report accuracy.`}
                     </p>
                     <div className="flex gap-2">
                       <button
@@ -496,7 +519,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
   );
 }
 
-function InputField({ label, name, value, unit, icon, onChange, onBlur, error, min, max, step, isDefault }: any) {
+function InputField({ label, name, value, unit, icon, onChange, onBlur, error, min, max, step, isDefault, carried }: any) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -506,9 +529,15 @@ function InputField({ label, name, value, unit, icon, onChange, onBlur, error, m
             <AlertCircle size={10} /> {error}
           </span>
         ) : isDefault ? (
-          <span className="text-[9px] font-bold text-ink-dim uppercase tracking-widest flex items-center gap-1.5">
-            <MinusCircle size={10} /> Default
-          </span>
+          carried ? (
+            <span className="text-[9px] font-bold text-accent/70 uppercase tracking-widest flex items-center gap-1.5">
+              <HistoryIcon size={10} /> Carried
+            </span>
+          ) : (
+            <span className="text-[9px] font-bold text-ink-dim uppercase tracking-widest flex items-center gap-1.5">
+              <MinusCircle size={10} /> Default
+            </span>
+          )
         ) : (
           <span className="text-[9px] font-bold text-success uppercase tracking-widest flex items-center gap-1.5">
             <Check size={10} /> Nominal

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -92,16 +92,23 @@ export default function ReadingForm({ onSave, onCancel, latestReading }: Props) 
   );
 
   // If `latestReading` arrives or changes after mount (e.g. Firestore snapshot lands
-  // after the form opens), re-seed any field the user hasn't touched. Touched fields
-  // are preserved so we don't clobber in-flight edits.
+  // after the form opens, or a newer reading replaces an older one), recompute every
+  // untouched field from a fresh fallback+latest base. This ensures fields missing
+  // from the new reading revert to the fallback constant rather than retaining stale
+  // values from a previous reading. Touched fields are preserved so we don't clobber
+  // in-flight edits.
   useEffect(() => {
     if (!latestReading) return;
+    const carried = carriedFromReading(latestReading);
+    const base: Record<NumericField, number> = { ...FALLBACK_NUMERIC };
+    for (const field of NUMERIC_FIELDS) {
+      if (carried.has(field)) base[field] = latestReading[field] as number;
+    }
     setFormData(prev => {
       const next = { ...prev };
       for (const field of NUMERIC_FIELDS) {
         if (touched.has(field)) continue;
-        const v = latestReading[field];
-        if (typeof v === 'number' && isFinite(v)) next[field] = v;
+        next[field] = base[field];
       }
       return next;
     });
@@ -109,17 +116,16 @@ export default function ReadingForm({ onSave, onCancel, latestReading }: Props) 
       const next = { ...prev };
       for (const field of NUMERIC_FIELDS) {
         if (touched.has(field)) continue;
-        const v = latestReading[field];
-        if (typeof v === 'number' && isFinite(v)) next[field] = String(v);
+        next[field] = String(base[field]);
       }
       return next;
     });
     setCarriedFields(prev => {
-      const next = new Set(prev);
+      // Preserve carried status for touched fields (their value may legitimately
+      // have come from a prior reading the user later edited); recompute the rest.
+      const next = new Set<NumericField>();
       for (const field of NUMERIC_FIELDS) {
-        if (touched.has(field)) continue;
-        const v = latestReading[field];
-        if (typeof v === 'number' && isFinite(v)) next.add(field);
+        if (touched.has(field) ? prev.has(field) : carried.has(field)) next.add(field);
       }
       return next;
     });

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { History as HistoryIcon } from 'lucide-react';
 import {
   Check,
   AlertCircle,
@@ -15,6 +14,7 @@ import {
   Waves,
   Sun,
   MinusCircle,
+  History as HistoryIcon,
 } from 'lucide-react';
 import { motion } from 'motion/react';
 import { GoogleGenAI } from "@google/genai";
@@ -50,6 +50,16 @@ const FALLBACK_NUMERIC: Record<NumericField, number> = {
   cyanuricAcid: 40,
 };
 
+function carriedFromReading(reading?: Reading): Set<NumericField> {
+  const set = new Set<NumericField>();
+  if (!reading) return set;
+  for (const field of NUMERIC_FIELDS) {
+    const v = reading[field];
+    if (typeof v === 'number' && isFinite(v)) set.add(field);
+  }
+  return set;
+}
+
 export default function ReadingForm({ onSave, onCancel, latestReading }: Props) {
   // Prefill from the most recent reading when available; fall back to typical values otherwise.
   const initialNumeric = React.useMemo<Record<NumericField, number>>(() => {
@@ -61,7 +71,6 @@ export default function ReadingForm({ onSave, onCancel, latestReading }: Props) 
     }
     return out;
   }, [latestReading]);
-  const carriedFromHistory = !!latestReading;
 
   const [formData, setFormData] = useState({
     ...initialNumeric,
@@ -74,6 +83,8 @@ export default function ReadingForm({ onSave, onCancel, latestReading }: Props) 
   const [errors, setErrors] = useState<Record<string, string>>({});
   // Tracks fields explicitly modified by the user (manual entry, voice transcription, or image upload)
   const [touched, setTouched] = useState<Set<NumericField>>(new Set());
+  // Tracks fields whose current value was actually copied from latestReading (vs. a fallback constant).
+  const [carriedFields, setCarriedFields] = useState<Set<NumericField>>(() => carriedFromReading(latestReading));
   const [showDefaultsWarning, setShowDefaultsWarning] = useState(false);
   const [isAnalyzingImage, setIsAnalyzingImage] = useState(false);
   const [rawInputs, setRawInputs] = useState<Record<string, string>>(
@@ -100,6 +111,15 @@ export default function ReadingForm({ onSave, onCancel, latestReading }: Props) 
         if (touched.has(field)) continue;
         const v = latestReading[field];
         if (typeof v === 'number' && isFinite(v)) next[field] = String(v);
+      }
+      return next;
+    });
+    setCarriedFields(prev => {
+      const next = new Set(prev);
+      for (const field of NUMERIC_FIELDS) {
+        if (touched.has(field)) continue;
+        const v = latestReading[field];
+        if (typeof v === 'number' && isFinite(v)) next.add(field);
       }
       return next;
     });
@@ -348,7 +368,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={10}
               step="any"
               isDefault={!touched.has('chlorine')}
-              carried={carriedFromHistory}
+              carried={carriedFields.has('chlorine')}
             />
             <InputField
               label="pH Level"
@@ -363,7 +383,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={14}
               step="any"
               isDefault={!touched.has('ph')}
-              carried={carriedFromHistory}
+              carried={carriedFields.has('ph')}
             />
             <InputField
               label="Total Alkalinity"
@@ -378,7 +398,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={300}
               step="any"
               isDefault={!touched.has('alkalinity')}
-              carried={carriedFromHistory}
+              carried={carriedFields.has('alkalinity')}
             />
             <InputField
               label="Temperature"
@@ -393,7 +413,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={50}
               step="any"
               isDefault={!touched.has('temperature')}
-              carried={carriedFromHistory}
+              carried={carriedFields.has('temperature')}
             />
             <InputField
               label="Diff Pressure"
@@ -408,7 +428,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={500}
               step="any"
               isDefault={!touched.has('differentialPressure')}
-              carried={carriedFromHistory}
+              carried={carriedFields.has('differentialPressure')}
             />
             <InputField
               label="Calcium Hardness"
@@ -423,7 +443,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={1000}
               step="any"
               isDefault={!touched.has('calciumHardness')}
-              carried={carriedFromHistory}
+              carried={carriedFields.has('calciumHardness')}
             />
             <InputField
               label="Cyanuric Acid"
@@ -438,7 +458,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               max={200}
               step="any"
               isDefault={!touched.has('cyanuricAcid')}
-              carried={carriedFromHistory}
+              carried={carriedFields.has('cyanuricAcid')}
             />
           </div>
 
@@ -497,16 +517,30 @@ missingInventory and missingEquipment should be arrays of strings when identifia
             <div className="max-w-2xl mx-auto space-y-3">
               {showDefaultsWarning && (() => {
                 const untouched = NUMERIC_FIELDS.filter(f => !touched.has(f));
+                const untouchedCarried = untouched.filter(f => carriedFields.has(f));
+                const untouchedFallback = untouched.filter(f => !carriedFields.has(f));
+                const hasFallback = untouchedFallback.length > 0;
+                const hasCarried = untouchedCarried.length > 0;
                 return (
                   <div className="p-4 rounded-xl bg-warning/10 border border-warning/40">
                     <div className="flex items-center gap-2 mb-2">
                       <AlertCircle size={14} className="text-warning flex-shrink-0" />
                       <span className="text-[10px] font-bold uppercase tracking-widest text-warning">
-                        {carriedFromHistory ? 'Some fields carried over' : 'Unsaved field defaults detected'}
+                        {hasFallback ? 'Unsaved field defaults detected' : 'Some fields carried over'}
                       </span>
                     </div>
                     <p className="text-xs text-ink-muted mb-3">
-                      <strong className="text-ink">{untouched.map(f => FIELD_LABELS[f]).join(', ')}</strong> {untouched.length === 1 ? 'was' : 'were'} not entered — {carriedFromHistory ? `${untouched.length === 1 ? 'the value' : 'values'} from your last reading will be saved.` : `the pre-filled estimate${untouched.length === 1 ? '' : 's'} will be saved and may affect report accuracy.`}
+                      {hasCarried && (
+                        <>
+                          <strong className="text-ink">{untouchedCarried.map(f => FIELD_LABELS[f]).join(', ')}</strong> {untouchedCarried.length === 1 ? 'will be carried over' : 'will be carried over'} from your last reading.
+                          {hasFallback && ' '}
+                        </>
+                      )}
+                      {hasFallback && (
+                        <>
+                          <strong className="text-ink">{untouchedFallback.map(f => FIELD_LABELS[f]).join(', ')}</strong> {untouchedFallback.length === 1 ? 'has' : 'have'} no prior value — the pre-filled estimate{untouchedFallback.length === 1 ? '' : 's'} will be saved and may affect report accuracy.
+                        </>
+                      )}
                     </p>
                     <div className="flex gap-2">
                       <button

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { History as HistoryIcon } from 'lucide-react';
 import {
   Check,
@@ -79,6 +79,31 @@ export default function ReadingForm({ onSave, onCancel, latestReading }: Props) 
   const [rawInputs, setRawInputs] = useState<Record<string, string>>(
     () => Object.fromEntries(NUMERIC_FIELDS.map(f => [f, String(initialNumeric[f])]))
   );
+
+  // If `latestReading` arrives or changes after mount (e.g. Firestore snapshot lands
+  // after the form opens), re-seed any field the user hasn't touched. Touched fields
+  // are preserved so we don't clobber in-flight edits.
+  useEffect(() => {
+    if (!latestReading) return;
+    setFormData(prev => {
+      const next = { ...prev };
+      for (const field of NUMERIC_FIELDS) {
+        if (touched.has(field)) continue;
+        const v = latestReading[field];
+        if (typeof v === 'number' && isFinite(v)) next[field] = v;
+      }
+      return next;
+    });
+    setRawInputs(prev => {
+      const next = { ...prev };
+      for (const field of NUMERIC_FIELDS) {
+        if (touched.has(field)) continue;
+        const v = latestReading[field];
+        if (typeof v === 'number' && isFinite(v)) next[field] = String(v);
+      }
+      return next;
+    });
+  }, [latestReading]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const validate = (name: string, value: number) => {
     const range = DEFAULT_RANGES[name as keyof typeof DEFAULT_RANGES];


### PR DESCRIPTION
## Summary
- Pre-fill `ReadingForm` numeric inputs from the most recent reading (when one exists) instead of hardcoded estimates like `chlorine: 1.5`, `ph: 7.4`, `alkalinity: 100`.
- Untouched fields now show a `Carried` badge (vs. the existing `Default` badge, which still appears when there is no prior reading).
- Warning banner copy reflects the new semantics: when carrying over, it says "Some fields carried over — values from your last reading will be saved" rather than implying generic estimates.

## Why
Previously, untouched fields silently saved fake-but-reasonable-looking numbers to Firestore, polluting LSI calculations, trend charts, and AI prompts. Calcium hardness and CYA in particular barely change day-to-day, so values from the previous log are typically much closer to truth than a static guess. This is a pragmatic fix that doesn't require a schema change.

A follow-up PR will introduce nullable reading fields (`number | null`) so "not measured" becomes a first-class state distinct from "measured as 0", which is the proper long-term fix.

## Test plan
- [ ] Open the form on a fresh account (no prior readings) — fields show `Default` badges with original fallback values.
- [ ] Open the form when at least one reading exists — fields show `Carried` badges with values from the most recent reading.
- [ ] Edit some fields, leave others — only edited fields lose their `Carried`/`Default` badge; warning banner copy matches whichever state applies.
- [ ] Voice input / image upload still populate fields and clear the badge.
- [ ] `npm run lint` passes.

https://claude.ai/code/session_016umL86wafiCDcKyibgszts

---
_Generated by [Claude Code](https://claude.ai/code/session_016umL86wafiCDcKyibgszts)_