### PR TITLE
Make reading numeric fields nullable to represent &quot;not measured&quot;

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -104,13 +104,21 @@ service cloud.firestore {
     // Domain Validators
     // ===============================================================
 
+    function isNumericOrNull(data, field) {
+      return !(field in data) || data[field] == null || data[field] is number;
+    }
+
     function isValidReading(data) {
-      return hasRequiredFields(['id', 'timestamp', 'chlorine', 'ph', 'alkalinity', 'uid']) &&
+      return hasRequiredFields(['id', 'timestamp', 'uid']) &&
              data.id is string &&
              data.timestamp is timestamp &&
-             data.chlorine is number &&
-             data.ph is number &&
-             data.alkalinity is number &&
+             isNumericOrNull(data, 'chlorine') &&
+             isNumericOrNull(data, 'ph') &&
+             isNumericOrNull(data, 'alkalinity') &&
+             isNumericOrNull(data, 'temperature') &&
+             isNumericOrNull(data, 'differentialPressure') &&
+             isNumericOrNull(data, 'calciumHardness') &&
+             isNumericOrNull(data, 'cyanuricAcid') &&
              data.uid == request.auth.uid;
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,15 +10,15 @@ service cloud.firestore {
     // Fields:
     //   - id: string (required)
     //   - timestamp: timestamp (required)
-    //   - chlorine: number (required)
-    //   - ph: number (required)
-    //   - alkalinity: number (required)
-    //   - temperature: number (required)
-    //   - differentialPressure: number (required)
-    //   - calciumHardness: number (required)
-    //   - cyanuricAcid: number (required)
-    //   - notes: string (optional)
     //   - uid: string (required)
+    //   - chlorine: number | null (optional — null/missing means "not measured")
+    //   - ph: number | null (optional — null/missing means "not measured")
+    //   - alkalinity: number | null (optional — null/missing means "not measured")
+    //   - temperature: number | null (optional — null/missing means "not measured")
+    //   - differentialPressure: number | null (optional — null/missing means "not measured")
+    //   - calciumHardness: number | null (optional — null/missing means "not measured")
+    //   - cyanuricAcid: number | null (optional — null/missing means "not measured")
+    //   - notes: string (optional)
     //
     // Collection: tasks
     // Document ID: auto-generated

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -474,15 +474,16 @@ export default function App() {
 
   const exportToCSV = () => {
     const headers = ['Timestamp', 'Chlorine (ppm)', 'pH', 'Alkalinity (ppm)', 'Temp (°C)', 'Diff Pressure (kPa)', 'Calcium Hardness (ppm)', 'CYA (ppm)', 'Notes'];
+    const csvNum = (v: number | null) => v == null ? '' : String(v);
     const rows = readings.map(r => [
       r.timestamp.toISOString(),
-      r.chlorine,
-      r.ph,
-      r.alkalinity,
-      r.temperature,
-      r.differentialPressure,
-      r.calciumHardness,
-      r.cyanuricAcid,
+      csvNum(r.chlorine),
+      csvNum(r.ph),
+      csvNum(r.alkalinity),
+      csvNum(r.temperature),
+      csvNum(r.differentialPressure),
+      csvNum(r.calciumHardness),
+      csvNum(r.cyanuricAcid),
       r.notes || '',
     ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,13 +299,28 @@ export default function App() {
       timestamp: now,
       uid: user.uid
     };
+    // A reading with no actual measurements doesn't count as a completed water
+    // test, so it shouldn't advance the schedule and suppress the next reminder.
+    const hasMeasurement =
+      newReading.chlorine != null ||
+      newReading.ph != null ||
+      newReading.alkalinity != null ||
+      newReading.temperature != null ||
+      newReading.differentialPressure != null ||
+      newReading.calciumHardness != null ||
+      newReading.cyanuricAcid != null;
 
     try {
       await setDoc(doc(db, 'readings', id), {
         ...reading,
         timestamp: Timestamp.fromDate(now)
       });
-      
+
+      if (!hasMeasurement) {
+        setIsLogging(false);
+        return;
+      }
+
       // Update schedule
       const daysToAdd = {
         daily: 1,

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -60,7 +60,7 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
   const [isLsiLoading, setIsLsiLoading] = React.useState(false);
   const latest = readings[0];
 
-  const lsiScore = latest ? calculateLSI(latest) : 0;
+  const lsiScore: number | null = latest ? calculateLSI(latest) : null;
 
   const getLsiStatus = (score: number): Status => {
     if (score < -0.3 || score > 0.3) return 'critical';
@@ -68,14 +68,16 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
     return 'good';
   };
 
+  const fmtField = (v: number | null | undefined) => v == null ? 'not measured' : String(v);
+
   const runLsiAnalysis = async () => {
-    if (!latest || isLsiLoading) return;
+    if (!latest || isLsiLoading || lsiScore == null) return;
     setIsLsiLoading(true);
     try {
       const response = await generateContentWithRetry({
         model: "gemini-2.0-flash",
         contents: `Analyze this LSI score of ${lsiScore} for a pool.
-        Context: pH ${latest.ph}, Temp ${latest.temperature}°C, CH ${latest.calciumHardness}, TA ${latest.alkalinity}.
+        Context: pH ${fmtField(latest.ph)}, Temp ${fmtField(latest.temperature)}°C, CH ${fmtField(latest.calciumHardness)}, TA ${fmtField(latest.alkalinity)}.
         Provide a 1-sentence technical recommendation.`,
       }, process.env.GEMINI_API_KEY!);
       setLsiAnalysis(response.text || "Analysis unavailable.");
@@ -112,7 +114,7 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
     {
       id: 'cl_low',
       type: 'chlorine',
-      condition: latest.chlorine < DEFAULT_RANGES.chlorine.min,
+      condition: latest.chlorine != null && latest.chlorine < DEFAULT_RANGES.chlorine.min,
       msg: 'Free chlorine critically low — pool unsafe. Dose now.',
       action: 'Add chlorine or shock treatment immediately.',
       severity: 'critical'
@@ -120,7 +122,7 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
     {
       id: 'cl_high',
       type: 'chlorine',
-      condition: latest.chlorine > DEFAULT_RANGES.chlorine.max,
+      condition: latest.chlorine != null && latest.chlorine > DEFAULT_RANGES.chlorine.max,
       msg: 'Chlorine elevated — likely post-shock.',
       action: 'Stop chlorination and wait for levels to drop.',
       severity: 'warning'
@@ -128,7 +130,7 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
     {
       id: 'ph_low',
       type: 'ph',
-      condition: latest.ph < DEFAULT_RANGES.ph.min,
+      condition: latest.ph != null && latest.ph < DEFAULT_RANGES.ph.min,
       msg: 'pH too low — corrosive water.',
       action: 'Add sodium carbonate (Soda Ash).',
       severity: 'critical'
@@ -136,7 +138,7 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
     {
       id: 'ph_high',
       type: 'ph',
-      condition: latest.ph > DEFAULT_RANGES.ph.max,
+      condition: latest.ph != null && latest.ph > DEFAULT_RANGES.ph.max,
       msg: 'pH too high — chlorine less effective.',
       action: 'Add muriatic acid.',
       severity: 'warning'
@@ -144,7 +146,7 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
     {
       id: 'alk_low',
       type: 'alkalinity',
-      condition: latest.alkalinity < DEFAULT_RANGES.alkalinity.min,
+      condition: latest.alkalinity != null && latest.alkalinity < DEFAULT_RANGES.alkalinity.min,
       msg: 'Low alkalinity — pH will be unstable.',
       action: 'Add sodium bicarbonate.',
       severity: 'warning'
@@ -152,7 +154,7 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
     {
       id: 'alk_high',
       type: 'alkalinity',
-      condition: latest.alkalinity > DEFAULT_RANGES.alkalinity.max,
+      condition: latest.alkalinity != null && latest.alkalinity > DEFAULT_RANGES.alkalinity.max,
       msg: 'Alkalinity is too high.',
       action: 'Add pH decreaser or partially drain.',
       severity: 'warning'
@@ -160,7 +162,7 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
     {
       id: 'dp_high',
       type: 'pressure',
-      condition: latest.differentialPressure > DEFAULT_RANGES.differentialPressure.max,
+      condition: latest.differentialPressure != null && latest.differentialPressure > DEFAULT_RANGES.differentialPressure.max,
       msg: 'Filter pressure elevated — flow restricted.',
       action: 'Backwash filter or clean cartridges immediately.',
       severity: 'critical'
@@ -200,10 +202,10 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
   };
 
   const getTrendData = (key: keyof Reading) => {
-    return readings.slice(0, 7).map(r => {
-      const val = r[key];
-      return typeof val === 'number' && !isNaN(val) ? val : 0;
-    }).reverse();
+    return readings.slice(0, 7)
+      .map(r => r[key])
+      .filter((v): v is number => typeof v === 'number' && !isNaN(v))
+      .reverse();
   };
 
   const handleAddTask = (e: React.FormEvent) => {
@@ -346,8 +348,9 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
             {/* Status Grid */}
             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
               <div className={`card anim-scan border col-span-2 md:col-span-1 flex flex-col justify-between p-4 ${
-                lsiScore < -0.3 ? 'text-red-400 border-red-500/30 bg-red-500/5' : 
-                lsiScore > 0.3 ? 'text-amber-400 border-amber-500/30 bg-amber-500/5' : 
+                lsiScore == null ? 'text-ink-dim border-border-dim bg-surface' :
+                lsiScore < -0.3 ? 'text-red-400 border-red-500/30 bg-red-500/5' :
+                lsiScore > 0.3 ? 'text-amber-400 border-amber-500/30 bg-amber-500/5' :
                 'text-emerald-400 border-emerald-500/30 bg-emerald-500/5'
               }`}>
                 <div className="flex items-center justify-between">
@@ -355,51 +358,51 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
                   <Sparkles size={14} className={isLsiLoading ? 'animate-spin' : ''} />
                 </div>
                 <div className="flex items-baseline gap-2">
-                  <span className="text-4xl font-bold font-mono">{lsiScore}</span>
+                  <span className="text-4xl font-bold font-mono">{lsiScore ?? '—'}</span>
                   <span className="text-[10px] uppercase tracking-widest opacity-70">
-                    {lsiScore < -0.3 ? 'Corrosive' : lsiScore > 0.3 ? 'Scale Forming' : 'Balanced'}
+                    {lsiScore == null ? 'Insufficient data' : lsiScore < -0.3 ? 'Corrosive' : lsiScore > 0.3 ? 'Scale Forming' : 'Balanced'}
                   </span>
                 </div>
                 <p className="text-[9px] mt-2 italic opacity-80 line-clamp-2">
-                  {isLsiLoading ? 'AI analyzing saturation...' : lsiAnalysis}
+                  {lsiScore == null ? 'Log pH, temperature, calcium hardness, and alkalinity to compute LSI.' : isLsiLoading ? 'AI analyzing saturation...' : lsiAnalysis}
                 </p>
               </div>
-              <StatusCard 
-                label="Free Chlorine" 
-                value={latest?.chlorine} 
-                unit="ppm" 
-                status={latest ? getStatus(latest.chlorine, DEFAULT_RANGES.chlorine.min, DEFAULT_RANGES.chlorine.max) : 'good'}
+              <StatusCard
+                label="Free Chlorine"
+                value={latest?.chlorine ?? null}
+                unit="ppm"
+                status={latest?.chlorine != null ? getStatus(latest.chlorine, DEFAULT_RANGES.chlorine.min, DEFAULT_RANGES.chlorine.max) : 'good'}
                 trend={getTrendData('chlorine')}
                 ideal="1–3"
               />
-              <StatusCard 
-                label="pH Level" 
-                value={latest?.ph} 
-                unit="" 
-                status={latest ? getStatus(latest.ph, DEFAULT_RANGES.ph.min, DEFAULT_RANGES.ph.max) : 'good'}
+              <StatusCard
+                label="pH Level"
+                value={latest?.ph ?? null}
+                unit=""
+                status={latest?.ph != null ? getStatus(latest.ph, DEFAULT_RANGES.ph.min, DEFAULT_RANGES.ph.max) : 'good'}
                 trend={getTrendData('ph')}
                 ideal="7.2–7.6"
               />
-              <StatusCard 
-                label="Alkalinity" 
-                value={latest?.alkalinity} 
-                unit="ppm" 
-                status={latest ? getStatus(latest.alkalinity, DEFAULT_RANGES.alkalinity.min, DEFAULT_RANGES.alkalinity.max) : 'good'}
+              <StatusCard
+                label="Alkalinity"
+                value={latest?.alkalinity ?? null}
+                unit="ppm"
+                status={latest?.alkalinity != null ? getStatus(latest.alkalinity, DEFAULT_RANGES.alkalinity.min, DEFAULT_RANGES.alkalinity.max) : 'good'}
                 trend={getTrendData('alkalinity')}
                 ideal="80–120"
               />
-              <StatusCard 
-                label="Diff Pressure" 
-                value={latest?.differentialPressure} 
-                unit="kPa" 
-                status={latest ? getStatus(latest.differentialPressure, DEFAULT_RANGES.differentialPressure.min, DEFAULT_RANGES.differentialPressure.max) : 'good'}
+              <StatusCard
+                label="Diff Pressure"
+                value={latest?.differentialPressure ?? null}
+                unit="kPa"
+                status={latest?.differentialPressure != null ? getStatus(latest.differentialPressure, DEFAULT_RANGES.differentialPressure.min, DEFAULT_RANGES.differentialPressure.max) : 'good'}
                 trend={getTrendData('differentialPressure')}
                 ideal="55–140"
               />
               <div className="card bg-[#0a1628] border-border-dim flex flex-col justify-between p-4">
                 <p className="text-[10px] font-bold uppercase tracking-widest text-ink-dim">Temperature</p>
                 <div className="flex items-baseline gap-1">
-                  <span className="text-3xl font-bold text-accent font-mono">{latest?.temperature ?? '--'}</span>
+                  <span className="text-3xl font-bold text-accent font-mono">{latest?.temperature ?? '—'}</span>
                   <span className="text-xs text-ink-dim">°C</span>
                 </div>
               </div>
@@ -582,19 +585,19 @@ export default function Dashboard({ readings, tasks, schedule, inventory, equipm
                     <div className="flex gap-4 text-[10px] font-mono">
                       <div className="text-center">
                         <p className="text-ink-dim mb-0.5">CL</p>
-                        <p className="font-bold text-accent">{reading.chlorine}</p>
+                        <p className="font-bold text-accent">{reading.chlorine ?? '—'}</p>
                       </div>
                       <div className="text-center">
                         <p className="text-ink-dim mb-0.5">PH</p>
-                        <p className="font-bold text-accent">{reading.ph}</p>
+                        <p className="font-bold text-accent">{reading.ph ?? '—'}</p>
                       </div>
                       <div className="text-center">
                         <p className="text-ink-dim mb-0.5">kPa</p>
-                        <p className="font-bold text-accent">{reading.differentialPressure}</p>
+                        <p className="font-bold text-accent">{reading.differentialPressure ?? '—'}</p>
                       </div>
                       <div className="text-center">
                         <p className="text-ink-dim mb-0.5">TEMP</p>
-                        <p className="font-bold text-accent">{reading.temperature}°</p>
+                        <p className="font-bold text-accent">{reading.temperature == null ? '—' : `${reading.temperature}°`}</p>
                       </div>
                     </div>
                   </div>
@@ -659,7 +662,7 @@ function Sparkline({ values, color }: { values: number[], color: string }) {
   );
 }
 
-function StatusCard({ label, value, unit, status, trend, ideal }: { label: string, value?: number, unit: string, status: Status, trend: number[], ideal: string }) {
+function StatusCard({ label, value, unit, status, trend, ideal }: { label: string, value: number | null, unit: string, status: Status, trend: number[], ideal: string }) {
   const statusColors = {
     good: 'text-emerald-400 border-emerald-500/30 bg-emerald-500/5',
     warning: 'text-amber-400 border-amber-500/30 bg-amber-500/5',
@@ -672,19 +675,21 @@ function StatusCard({ label, value, unit, status, trend, ideal }: { label: strin
     critical: '#ef4444',
   };
 
+  const isMissing = value == null;
+
   return (
-    <div className={`card anim-scan border ${statusColors[status]} flex flex-col gap-2 p-4`}>
+    <div className={`card anim-scan border ${isMissing ? 'text-ink-dim border-border-dim bg-surface' : statusColors[status]} flex flex-col gap-2 p-4`}>
       <div className="flex items-center justify-between">
         <p className="text-[10px] font-bold uppercase tracking-widest text-ink-dim">{label}</p>
         <Sparkline values={trend} color={sparklineColors[status]} />
       </div>
       <div className="flex items-baseline gap-1">
-        <span className="text-3xl font-bold font-mono">{value?.toFixed(label === 'pH Level' ? 1 : 0) ?? '--'}</span>
+        <span className="text-3xl font-bold font-mono">{isMissing ? '—' : value.toFixed(label === 'pH Level' ? 1 : 0)}</span>
         <span className="text-[10px] text-ink-dim font-medium">{unit}</span>
       </div>
       <div className="flex items-center justify-between text-[9px] font-bold uppercase tracking-widest">
         <span className="text-ink-dim">Ideal: {ideal}</span>
-        <span className="opacity-80">{status === 'good' ? '✓ OK' : status === 'warning' ? '⚠ Watch' : '✕ Action'}</span>
+        <span className="opacity-80">{isMissing ? 'Not measured' : status === 'good' ? '✓ OK' : status === 'warning' ? '⚠ Watch' : '✕ Action'}</span>
       </div>
     </div>
   );

--- a/src/components/GeminiAssistant.tsx
+++ b/src/components/GeminiAssistant.tsx
@@ -166,10 +166,11 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
     setLoading(true);
     setError(null);
     setIsMapsMode(false);
-    
+
     try {
       const lsi = calculateLSI(latestReading);
-      
+      const fmt = (v: number | null | undefined) => v == null ? 'not measured' : String(v);
+
       const recentNotes = history
         .slice(0, 5)
         .filter(r => r.notes)
@@ -179,14 +180,14 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
       const prompt = `
         You are an expert pool maintenance system (PoolStatus AI). 
         Analyze the following telemetry data:
-        - Free Chlorine: ${latestReading.chlorine} ppm
-        - pH Level: ${latestReading.ph}
-        - Total Alkalinity: ${latestReading.alkalinity} ppm
-        - Water Temperature: ${latestReading.temperature}°C
-        - Calcium Hardness: ${latestReading.calciumHardness} ppm
-        - Cyanuric Acid: ${latestReading.cyanuricAcid} ppm
-        - Differential Pressure: ${latestReading.differentialPressure} kPa
-        - Calculated LSI: ${lsi}
+        - Free Chlorine: ${fmt(latestReading.chlorine)} ppm
+        - pH Level: ${fmt(latestReading.ph)}
+        - Total Alkalinity: ${fmt(latestReading.alkalinity)} ppm
+        - Water Temperature: ${fmt(latestReading.temperature)}°C
+        - Calcium Hardness: ${fmt(latestReading.calciumHardness)} ppm
+        - Cyanuric Acid: ${fmt(latestReading.cyanuricAcid)} ppm
+        - Differential Pressure: ${fmt(latestReading.differentialPressure)} kPa
+        - Calculated LSI: ${lsi == null ? 'not computable (missing inputs)' : lsi}
         
         RECENT MAINTENANCE HISTORY:
         ${recentNotes || 'No recent maintenance recorded.'}
@@ -265,10 +266,11 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
 
   const buildReportSummary = () => {
     if (!insight || !latestReading) return '';
+    const fmt = (v: number | null | undefined) => v == null ? '—' : String(v);
     const checklist = insight.checklist.map((item, idx) => `${idx + 1}. ${item.title}`).join(' | ');
     return [
       `AI Analysis (${new Date().toLocaleString()})`,
-      `Reading: Cl ${latestReading.chlorine} ppm, pH ${latestReading.ph}, TA ${latestReading.alkalinity} ppm, Temp ${latestReading.temperature}°C`,
+      `Reading: Cl ${fmt(latestReading.chlorine)} ppm, pH ${fmt(latestReading.ph)}, TA ${fmt(latestReading.alkalinity)} ppm, Temp ${fmt(latestReading.temperature)}°C`,
       `Assessment: ${insight.analysis.replace(/\n+/g, ' ').trim()}`,
       `Checklist: ${checklist}`,
       `Target Outcome: ${insight.expectedOutcome.replace(/\n+/g, ' ').trim()}`
@@ -287,16 +289,17 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
 
   const exportSnapshot = () => {
     if (!insight || !latestReading) return;
+    const fmt = (v: number | null | undefined) => v == null ? 'not measured' : String(v);
     const report = [
       '# PoolStatus AI Telemetry Snapshot',
       `Generated: ${new Date().toLocaleString()}`,
       '',
       '## Current Reading',
-      `- Free Chlorine: ${latestReading.chlorine} ppm`,
-      `- pH: ${latestReading.ph}`,
-      `- Alkalinity: ${latestReading.alkalinity} ppm`,
-      `- Temperature: ${latestReading.temperature}°C`,
-      `- Differential Pressure: ${latestReading.differentialPressure} kPa`,
+      `- Free Chlorine: ${fmt(latestReading.chlorine)} ppm`,
+      `- pH: ${fmt(latestReading.ph)}`,
+      `- Alkalinity: ${fmt(latestReading.alkalinity)} ppm`,
+      `- Temperature: ${fmt(latestReading.temperature)}°C`,
+      `- Differential Pressure: ${fmt(latestReading.differentialPressure)} kPa`,
       '',
       '## Health Assessment',
       insight.analysis,
@@ -351,8 +354,9 @@ export default function GeminiAssistant({ latestReading, history, onExecuteProto
     setIsMapsMode(false);
 
     try {
+      const fmt = (v: number | null | undefined) => v == null ? 'not measured' : String(v);
       const context = latestReading
-        ? `Latest reading context: FC ${latestReading.chlorine} ppm, pH ${latestReading.ph}, TA ${latestReading.alkalinity} ppm, Temp ${latestReading.temperature}°C, CYA ${latestReading.cyanuricAcid} ppm.`
+        ? `Latest reading context: FC ${fmt(latestReading.chlorine)} ppm, pH ${fmt(latestReading.ph)} TA ${fmt(latestReading.alkalinity)} ppm, Temp ${fmt(latestReading.temperature)}°C, CYA ${fmt(latestReading.cyanuricAcid)} ppm.`
         : 'No latest reading is currently available.';
       const response = await callAiWithFallback({
         model: "gemini-3-flash-preview",

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -104,7 +104,8 @@ export default function History({ readings, onBack, onDelete }: Props) {
   );
 }
 
-function DataPoint({ label, value, unit, icon, color }: any) {
+function DataPoint({ label, value, unit, icon, color }: { label: string; value: number | null; unit: string; icon: React.ReactNode; color: string }) {
+  const isMissing = value == null;
   return (
     <div className="space-y-1">
       <div className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-widest text-ink-dim">
@@ -112,7 +113,9 @@ function DataPoint({ label, value, unit, icon, color }: any) {
         {label}
       </div>
       <div className="flex items-baseline gap-1">
-        <span className={`text-lg font-bold font-mono ${color}`}>{value.toFixed(label === 'pH Level' ? 1 : 0)}</span>
+        <span className={`text-lg font-bold font-mono ${isMissing ? 'text-ink-dim' : color}`}>
+          {isMissing ? '—' : value.toFixed(label === 'pH Level' ? 1 : 0)}
+        </span>
         <span className="text-[9px] text-ink-dim font-bold uppercase">{unit}</span>
       </div>
     </div>

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -16,7 +16,6 @@ import {
   MinusCircle,
 } from 'lucide-react';
 import { motion } from 'motion/react';
-import { GoogleGenAI } from "@google/genai";
 import { Reading, DEFAULT_RANGES } from '../types';
 import { generateContentWithRetry } from '../lib/gemini';
 
@@ -28,43 +27,40 @@ interface Props {
 const NUMERIC_FIELDS = ['chlorine', 'ph', 'alkalinity', 'temperature', 'differentialPressure', 'calciumHardness', 'cyanuricAcid'] as const;
 type NumericField = typeof NUMERIC_FIELDS[number];
 
-const FIELD_LABELS: Record<NumericField, string> = {
-  chlorine: 'Free Chlorine',
-  ph: 'pH Level',
-  alkalinity: 'Total Alkalinity',
-  temperature: 'Temperature',
-  differentialPressure: 'Diff. Pressure',
-  calciumHardness: 'Calcium Hardness',
-  cyanuricAcid: 'Cyanuric Acid',
+type FormData = Record<NumericField, number | null> & {
+  notes: string;
+  uid: string;
 };
 
-const INITIAL_NUMERIC: Record<NumericField, number> = {
-  chlorine: 1.5,
-  ph: 7.4,
-  alkalinity: 100,
-  temperature: 26,
-  differentialPressure: 12,
-  calciumHardness: 300,
-  cyanuricAcid: 40,
+const INITIAL_FORM: FormData = {
+  chlorine: null,
+  ph: null,
+  alkalinity: null,
+  temperature: null,
+  differentialPressure: null,
+  calciumHardness: null,
+  cyanuricAcid: null,
+  notes: '',
+  uid: '',
+};
+
+const INITIAL_RAW: Record<NumericField, string> = {
+  chlorine: '',
+  ph: '',
+  alkalinity: '',
+  temperature: '',
+  differentialPressure: '',
+  calciumHardness: '',
+  cyanuricAcid: '',
 };
 
 export default function ReadingForm({ onSave, onCancel }: Props) {
-  const [formData, setFormData] = useState({
-    ...INITIAL_NUMERIC,
-    notes: '',
-    uid: '',
-  });
-
+  const [formData, setFormData] = useState<FormData>(INITIAL_FORM);
+  const [rawInputs, setRawInputs] = useState<Record<NumericField, string>>(INITIAL_RAW);
+  const [errors, setErrors] = useState<Record<string, string>>({});
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [isTranscribingNotes, setIsTranscribingNotes] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  // Tracks fields explicitly modified by the user (manual entry, voice transcription, or image upload)
-  const [touched, setTouched] = useState<Set<NumericField>>(new Set());
-  const [showDefaultsWarning, setShowDefaultsWarning] = useState(false);
   const [isAnalyzingImage, setIsAnalyzingImage] = useState(false);
-  const [rawInputs, setRawInputs] = useState<Record<string, string>>(
-    () => Object.fromEntries(NUMERIC_FIELDS.map(f => [f, String(INITIAL_NUMERIC[f])]))
-  );
 
   const validate = (name: string, value: number) => {
     const range = DEFAULT_RANGES[name as keyof typeof DEFAULT_RANGES];
@@ -78,17 +74,16 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
     const { name, value, type } = e.target;
 
     if (type === 'number') {
-      setRawInputs(prev => ({ ...prev, [name]: value }));
-      setTouched(prev => { const n = new Set(prev); n.add(name as NumericField); return n; });
-      setShowDefaultsWarning(false);
+      const fieldName = name as NumericField;
+      setRawInputs(prev => ({ ...prev, [fieldName]: value }));
       if (value === '' || value.endsWith('.')) {
-        // Mid-entry — clear stale error so UI doesn't show an outdated state
-        setErrors(prev => ({ ...prev, [name]: '' }));
+        setFormData(prev => ({ ...prev, [fieldName]: value === '' ? null : prev[fieldName] }));
+        setErrors(prev => ({ ...prev, [fieldName]: '' }));
       } else {
         const parsed = parseFloat(value);
         if (!isNaN(parsed)) {
-          setFormData(prev => ({ ...prev, [name]: parsed }));
-          setErrors(prev => ({ ...prev, [name]: validate(name, parsed) }));
+          setFormData(prev => ({ ...prev, [fieldName]: parsed }));
+          setErrors(prev => ({ ...prev, [fieldName]: validate(fieldName, parsed) }));
         }
       }
     } else {
@@ -98,35 +93,45 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
+    const fieldName = name as NumericField;
+    if (value === '') {
+      setFormData(prev => ({ ...prev, [fieldName]: null }));
+      setErrors(prev => ({ ...prev, [fieldName]: '' }));
+      return;
+    }
     const parsed = parseFloat(value);
-    const num = isNaN(parsed) ? 0 : parsed;
-    setRawInputs(prev => ({ ...prev, [name]: String(num) }));
-    setFormData(prev => ({ ...prev, [name]: num }));
-    setErrors(prev => ({ ...prev, [name]: validate(name, num) }));
+    if (isNaN(parsed)) {
+      setRawInputs(prev => ({ ...prev, [fieldName]: '' }));
+      setFormData(prev => ({ ...prev, [fieldName]: null }));
+      setErrors(prev => ({ ...prev, [fieldName]: '' }));
+      return;
+    }
+    setRawInputs(prev => ({ ...prev, [fieldName]: String(parsed) }));
+    setFormData(prev => ({ ...prev, [fieldName]: parsed }));
+    setErrors(prev => ({ ...prev, [fieldName]: validate(fieldName, parsed) }));
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // Flush any rawInputs that are still mid-edit (e.g. focused field ending with ".")
-    const flushed = { ...formData };
+    // Flush any rawInputs that are still mid-edit (e.g. focused field ending with ".").
+    // Empty strings remain null — "not measured" is a valid state.
+    const flushed: FormData = { ...formData };
     for (const field of NUMERIC_FIELDS) {
-      const parsed = parseFloat(rawInputs[field] ?? '');
-      if (!isNaN(parsed)) flushed[field] = parsed;
+      const raw = rawInputs[field] ?? '';
+      if (raw === '') {
+        flushed[field] = null;
+      } else {
+        const parsed = parseFloat(raw);
+        if (!isNaN(parsed)) flushed[field] = parsed;
+      }
     }
-    // Warn if any measurement fields are still at their pre-filled defaults
-    const untouched = NUMERIC_FIELDS.filter(f => !touched.has(f));
-    if (untouched.length > 0 && !showDefaultsWarning) {
-      setShowDefaultsWarning(true);
-      return;
-    }
-    setShowDefaultsWarning(false);
     onSave(flushed);
   };
 
   const handleVoiceInput = async (targetField: 'all' | 'notes' = 'all') => {
     const isNotes = targetField === 'notes';
     if (isNotes ? isTranscribingNotes : isTranscribing) return;
-    
+
     if (isNotes) setIsTranscribingNotes(true);
     else setIsTranscribing(true);
 
@@ -145,7 +150,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
         reader.readAsDataURL(audioBlob);
         reader.onloadend = async () => {
           const base64Audio = (reader.result as string).split(',')[1];
-          
+
           const response = await generateContentWithRetry({
             model: "gemini-3-flash-preview",
             contents: [
@@ -156,7 +161,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
                 }
               },
               {
-                text: isNotes 
+                text: isNotes
                   ? "Transcribe the following pool maintenance observations or chemical additions. Return ONLY the transcribed text."
                   : "Transcribe the following pool reading. Extract values for Chlorine, pH, Alkalinity, Temperature, Pressure, Calcium, and CYA if mentioned. Return ONLY a JSON object with these keys: chlorine, ph, alkalinity, temperature, differentialPressure, calciumHardness, cyanuricAcid, notes."
               }
@@ -175,7 +180,6 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
               }));
             } else {
               const result = JSON.parse(response.text || '{}');
-              // Only accept fields where transcription returned a parseable finite number
               const validFields: Partial<Record<NumericField, number>> = {};
               for (const field of NUMERIC_FIELDS) {
                 const parsed = parseFloat(String(result[field]));
@@ -186,11 +190,6 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
                 ...prev,
                 ...Object.fromEntries(Object.entries(validFields).map(([k, v]) => [k, String(v)])),
               }));
-              setTouched(prev => {
-                const n = new Set(prev);
-                for (const field of Object.keys(validFields) as NumericField[]) n.add(field);
-                return n;
-              });
             }
           } catch (e) {
             console.error("Failed to process transcription", e);
@@ -239,7 +238,6 @@ missingInventory and missingEquipment should be arrays of strings when identifia
         config: { responseMimeType: "application/json" }
       }, process.env.GEMINI_API_KEY!);
       const parsed = JSON.parse(response.text || '{}');
-      // Only accept fields where the image extraction returned a parseable finite number
       const validFields: Partial<Record<NumericField, number>> = {};
       for (const field of NUMERIC_FIELDS) {
         const v = parseFloat(String(parsed[field]));
@@ -259,11 +257,6 @@ missingInventory and missingEquipment should be arrays of strings when identifia
         ...prev,
         ...Object.fromEntries(Object.entries(validFields).map(([k, v]) => [k, String(v)])),
       }));
-      setTouched(prev => {
-        const n = new Set(prev);
-        for (const field of Object.keys(validFields) as NumericField[]) n.add(field);
-        return n;
-      });
     } catch (error) {
       console.error('Image analysis failed', error);
     } finally {
@@ -273,7 +266,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
   };
 
   return (
-    <motion.div 
+    <motion.div
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95 }}
@@ -281,8 +274,8 @@ missingInventory and missingEquipment should be arrays of strings when identifia
     >
       <div className="max-w-2xl mx-auto px-4 py-8 space-y-10">
         <header className="flex items-center justify-between border-b border-border-dim pb-6">
-          <button 
-            onClick={onCancel} 
+          <button
+            onClick={onCancel}
             className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest text-ink-dim hover:text-accent transition-colors"
           >
             <ChevronLeft size={16} />
@@ -296,104 +289,13 @@ missingInventory and missingEquipment should be arrays of strings when identifia
 
         <form onSubmit={handleSubmit} noValidate className="space-y-10 pb-32">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            <InputField
-              label="Free Chlorine"
-              name="chlorine"
-              value={rawInputs.chlorine}
-              unit="ppm"
-              icon={<Droplets size={16} />}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={errors.chlorine}
-              min={0}
-              max={10}
-              step="any"
-              isDefault={!touched.has('chlorine')}
-            />
-            <InputField
-              label="pH Level"
-              name="ph"
-              value={rawInputs.ph}
-              unit=""
-              icon={<Activity size={16} />}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={errors.ph}
-              min={0}
-              max={14}
-              step="any"
-              isDefault={!touched.has('ph')}
-            />
-            <InputField
-              label="Total Alkalinity"
-              name="alkalinity"
-              value={rawInputs.alkalinity}
-              unit="ppm"
-              icon={<TrendingUp size={16} />}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={errors.alkalinity}
-              min={0}
-              max={300}
-              step="any"
-              isDefault={!touched.has('alkalinity')}
-            />
-            <InputField
-              label="Temperature"
-              name="temperature"
-              value={rawInputs.temperature}
-              unit="°C"
-              icon={<Thermometer size={16} />}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={errors.temperature}
-              min={0}
-              max={50}
-              step="any"
-              isDefault={!touched.has('temperature')}
-            />
-            <InputField
-              label="Diff Pressure"
-              name="differentialPressure"
-              value={rawInputs.differentialPressure}
-              unit="kPa"
-              icon={<Gauge size={16} />}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={errors.differentialPressure}
-              min={0}
-              max={500}
-              step="any"
-              isDefault={!touched.has('differentialPressure')}
-            />
-            <InputField
-              label="Calcium Hardness"
-              name="calciumHardness"
-              value={rawInputs.calciumHardness}
-              unit="ppm"
-              icon={<Waves size={16} />}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={errors.calciumHardness}
-              min={0}
-              max={1000}
-              step="any"
-              isDefault={!touched.has('calciumHardness')}
-            />
-            <InputField
-              label="Cyanuric Acid"
-              name="cyanuricAcid"
-              value={rawInputs.cyanuricAcid}
-              unit="ppm"
-              icon={<Sun size={16} />}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={errors.cyanuricAcid}
-              min={0}
-              max={200}
-              step="any"
-              isDefault={!touched.has('cyanuricAcid')}
-            />
+            <InputField label="Free Chlorine" name="chlorine" value={rawInputs.chlorine} unit="ppm" icon={<Droplets size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.chlorine} min={0} max={10} step="any" isEmpty={formData.chlorine == null} />
+            <InputField label="pH Level" name="ph" value={rawInputs.ph} unit="" icon={<Activity size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.ph} min={0} max={14} step="any" isEmpty={formData.ph == null} />
+            <InputField label="Total Alkalinity" name="alkalinity" value={rawInputs.alkalinity} unit="ppm" icon={<TrendingUp size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.alkalinity} min={0} max={300} step="any" isEmpty={formData.alkalinity == null} />
+            <InputField label="Temperature" name="temperature" value={rawInputs.temperature} unit="°C" icon={<Thermometer size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.temperature} min={0} max={50} step="any" isEmpty={formData.temperature == null} />
+            <InputField label="Diff Pressure" name="differentialPressure" value={rawInputs.differentialPressure} unit="kPa" icon={<Gauge size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.differentialPressure} min={0} max={500} step="any" isEmpty={formData.differentialPressure == null} />
+            <InputField label="Calcium Hardness" name="calciumHardness" value={rawInputs.calciumHardness} unit="ppm" icon={<Waves size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.calciumHardness} min={0} max={1000} step="any" isEmpty={formData.calciumHardness == null} />
+            <InputField label="Cyanuric Acid" name="cyanuricAcid" value={rawInputs.cyanuricAcid} unit="ppm" icon={<Sun size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.cyanuricAcid} min={0} max={200} step="any" isEmpty={formData.cyanuricAcid == null} />
           </div>
 
           <div className="flex items-center gap-4 p-4 bg-bg/40 rounded-xl border border-border-dim">
@@ -438,7 +340,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
               </div>
               <span className="text-[9px] font-bold uppercase tracking-widest text-ink-dim/50">Optional</span>
             </div>
-            <textarea 
+            <textarea
               name="notes"
               value={formData.notes}
               onChange={handleChange}
@@ -448,46 +350,14 @@ missingInventory and missingEquipment should be arrays of strings when identifia
           </div>
 
           <div className="fixed bottom-0 left-0 right-0 p-6 bg-[#060e1a]/95 backdrop-blur-xl border-t border-border-dim">
-            <div className="max-w-2xl mx-auto space-y-3">
-              {showDefaultsWarning && (() => {
-                const untouched = NUMERIC_FIELDS.filter(f => !touched.has(f));
-                return (
-                  <div className="p-4 rounded-xl bg-warning/10 border border-warning/40">
-                    <div className="flex items-center gap-2 mb-2">
-                      <AlertCircle size={14} className="text-warning flex-shrink-0" />
-                      <span className="text-[10px] font-bold uppercase tracking-widest text-warning">Unsaved field defaults detected</span>
-                    </div>
-                    <p className="text-xs text-ink-muted mb-3">
-                      <strong className="text-ink">{untouched.map(f => FIELD_LABELS[f]).join(', ')}</strong> {untouched.length === 1 ? 'was' : 'were'} not entered — the pre-filled estimate{untouched.length === 1 ? '' : 's'} will be saved and may affect report accuracy.
-                    </p>
-                    <div className="flex gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setShowDefaultsWarning(false)}
-                        className="btn btn-secondary py-2 flex-1"
-                      >
-                        Review Fields
-                      </button>
-                      <button
-                        type="submit"
-                        className="btn btn-primary py-2 flex-1"
-                      >
-                        <Save size={14} />
-                        Save Anyway
-                      </button>
-                    </div>
-                  </div>
-                );
-              })()}
-              {!showDefaultsWarning && (
-                <button
-                  type="submit"
-                  className="btn btn-primary w-full py-5 text-xs font-bold uppercase tracking-[0.2em] gap-3 shadow-2xl shadow-accent/20"
-                >
-                  <Save size={18} />
-                  Commit to Database
-                </button>
-              )}
+            <div className="max-w-2xl mx-auto">
+              <button
+                type="submit"
+                className="btn btn-primary w-full py-5 text-xs font-bold uppercase tracking-[0.2em] gap-3 shadow-2xl shadow-accent/20"
+              >
+                <Save size={18} />
+                Commit to Database
+              </button>
             </div>
           </div>
         </form>
@@ -496,7 +366,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
   );
 }
 
-function InputField({ label, name, value, unit, icon, onChange, onBlur, error, min, max, step, isDefault }: any) {
+function InputField({ label, name, value, unit, icon, onChange, onBlur, error, min, max, step, isEmpty }: any) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -505,9 +375,9 @@ function InputField({ label, name, value, unit, icon, onChange, onBlur, error, m
           <span className="text-[9px] font-bold text-critical uppercase tracking-widest flex items-center gap-1.5">
             <AlertCircle size={10} /> {error}
           </span>
-        ) : isDefault ? (
+        ) : isEmpty ? (
           <span className="text-[9px] font-bold text-ink-dim uppercase tracking-widest flex items-center gap-1.5">
-            <MinusCircle size={10} /> Default
+            <MinusCircle size={10} /> Not measured
           </span>
         ) : (
           <span className="text-[9px] font-bold text-success uppercase tracking-widest flex items-center gap-1.5">
@@ -528,6 +398,7 @@ function InputField({ label, name, value, unit, icon, onChange, onBlur, error, m
           min={min}
           max={max}
           step={step}
+          placeholder="—"
           className={`input bg-[#0d1f38] pl-12 pr-16 py-4 text-sm font-mono ${error ? 'border-critical focus:ring-critical/10' : 'border-border-dim focus:border-accent focus:ring-accent/10'}`}
         />
         <div className="absolute right-4 top-1/2 -translate-y-1/2 text-[10px] font-bold text-ink-dim uppercase tracking-widest">

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -74,6 +74,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
     if (type === 'number') {
       const fieldName = name as NumericField;
       setRawInputs(prev => ({ ...prev, [fieldName]: value }));
+      if (value !== '') setSubmitError(null);
       if (value === '' || value.endsWith('.')) {
         setFormData(prev => ({ ...prev, [fieldName]: value === '' ? null : prev[fieldName] }));
         setErrors(prev => ({ ...prev, [fieldName]: '' }));
@@ -109,6 +110,8 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
     setErrors(prev => ({ ...prev, [fieldName]: validate(fieldName, parsed) }));
   };
 
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     // Flush any rawInputs that are still mid-edit (e.g. focused field ending with ".").
@@ -123,6 +126,14 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
         if (!isNaN(parsed)) flushed[field] = parsed;
       }
     }
+    // Block all-null submissions: every numeric field would be saved as "not
+    // measured", which advances the test schedule without any actual data.
+    const hasAnyMeasurement = NUMERIC_FIELDS.some(f => flushed[f] != null);
+    if (!hasAnyMeasurement) {
+      setSubmitError('Enter at least one measurement before saving.');
+      return;
+    }
+    setSubmitError(null);
     onSave(flushed);
   };
 
@@ -348,7 +359,13 @@ missingInventory and missingEquipment should be arrays of strings when identifia
           </div>
 
           <div className="fixed bottom-0 left-0 right-0 p-6 bg-[#060e1a]/95 backdrop-blur-xl border-t border-border-dim">
-            <div className="max-w-2xl mx-auto">
+            <div className="max-w-2xl mx-auto space-y-3">
+              {submitError && (
+                <div className="flex items-center gap-2 p-3 rounded-xl bg-critical/10 border border-critical/40">
+                  <AlertCircle size={14} className="text-critical flex-shrink-0" />
+                  <span className="text-xs text-critical">{submitError}</span>
+                </div>
+              )}
               <button
                 type="submit"
                 className="btn btn-primary w-full py-5 text-xs font-bold uppercase tracking-[0.2em] gap-3 shadow-2xl shadow-accent/20"

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -20,7 +20,7 @@ import { Reading, DEFAULT_RANGES } from '../types';
 import { generateContentWithRetry } from '../lib/gemini';
 
 interface Props {
-  onSave: (reading: Omit<Reading, 'id' | 'timestamp'>) => void;
+  onSave: (reading: Omit<Reading, 'id' | 'timestamp' | 'uid'>) => void;
   onCancel: () => void;
 }
 
@@ -29,7 +29,6 @@ type NumericField = typeof NUMERIC_FIELDS[number];
 
 type FormData = Record<NumericField, number | null> & {
   notes: string;
-  uid: string;
 };
 
 const INITIAL_FORM: FormData = {
@@ -41,7 +40,6 @@ const INITIAL_FORM: FormData = {
   calciumHardness: null,
   cyanuricAcid: null,
   notes: '',
-  uid: '',
 };
 
 const INITIAL_RAW: Record<NumericField, string> = {
@@ -289,13 +287,13 @@ missingInventory and missingEquipment should be arrays of strings when identifia
 
         <form onSubmit={handleSubmit} noValidate className="space-y-10 pb-32">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            <InputField label="Free Chlorine" name="chlorine" value={rawInputs.chlorine} unit="ppm" icon={<Droplets size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.chlorine} min={0} max={10} step="any" isEmpty={formData.chlorine == null} />
-            <InputField label="pH Level" name="ph" value={rawInputs.ph} unit="" icon={<Activity size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.ph} min={0} max={14} step="any" isEmpty={formData.ph == null} />
-            <InputField label="Total Alkalinity" name="alkalinity" value={rawInputs.alkalinity} unit="ppm" icon={<TrendingUp size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.alkalinity} min={0} max={300} step="any" isEmpty={formData.alkalinity == null} />
-            <InputField label="Temperature" name="temperature" value={rawInputs.temperature} unit="°C" icon={<Thermometer size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.temperature} min={0} max={50} step="any" isEmpty={formData.temperature == null} />
-            <InputField label="Diff Pressure" name="differentialPressure" value={rawInputs.differentialPressure} unit="kPa" icon={<Gauge size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.differentialPressure} min={0} max={500} step="any" isEmpty={formData.differentialPressure == null} />
-            <InputField label="Calcium Hardness" name="calciumHardness" value={rawInputs.calciumHardness} unit="ppm" icon={<Waves size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.calciumHardness} min={0} max={1000} step="any" isEmpty={formData.calciumHardness == null} />
-            <InputField label="Cyanuric Acid" name="cyanuricAcid" value={rawInputs.cyanuricAcid} unit="ppm" icon={<Sun size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.cyanuricAcid} min={0} max={200} step="any" isEmpty={formData.cyanuricAcid == null} />
+            <InputField label="Free Chlorine" name="chlorine" value={rawInputs.chlorine} unit="ppm" icon={<Droplets size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.chlorine} min={0} max={10} step="any" isEmpty={rawInputs.chlorine === ''} />
+            <InputField label="pH Level" name="ph" value={rawInputs.ph} unit="" icon={<Activity size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.ph} min={0} max={14} step="any" isEmpty={rawInputs.ph === ''} />
+            <InputField label="Total Alkalinity" name="alkalinity" value={rawInputs.alkalinity} unit="ppm" icon={<TrendingUp size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.alkalinity} min={0} max={300} step="any" isEmpty={rawInputs.alkalinity === ''} />
+            <InputField label="Temperature" name="temperature" value={rawInputs.temperature} unit="°C" icon={<Thermometer size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.temperature} min={0} max={50} step="any" isEmpty={rawInputs.temperature === ''} />
+            <InputField label="Diff Pressure" name="differentialPressure" value={rawInputs.differentialPressure} unit="kPa" icon={<Gauge size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.differentialPressure} min={0} max={500} step="any" isEmpty={rawInputs.differentialPressure === ''} />
+            <InputField label="Calcium Hardness" name="calciumHardness" value={rawInputs.calciumHardness} unit="ppm" icon={<Waves size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.calciumHardness} min={0} max={1000} step="any" isEmpty={rawInputs.calciumHardness === ''} />
+            <InputField label="Cyanuric Acid" name="cyanuricAcid" value={rawInputs.cyanuricAcid} unit="ppm" icon={<Sun size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.cyanuricAcid} min={0} max={200} step="any" isEmpty={rawInputs.cyanuricAcid === ''} />
           </div>
 
           <div className="flex items-center gap-4 p-4 bg-bg/40 rounded-xl border border-border-dim">

--- a/src/components/TrendCharts.tsx
+++ b/src/components/TrendCharts.tsx
@@ -17,18 +17,19 @@ interface Props {
 }
 
 export default function TrendCharts({ readings }: Props) {
-  // Sort readings by date ascending for the chart
+  // Preserve nulls so Recharts renders gaps for unmeasured fields rather than plotting fake zeros.
+  const num = (v: number | null) => (typeof v === 'number' && !isNaN(v) ? v : null);
   const chartData = [...readings]
     .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
     .map(r => ({
       ...r,
-      chlorine: Number(r.chlorine) || 0,
-      ph: Number(r.ph) || 0,
-      alkalinity: Number(r.alkalinity) || 0,
-      temperature: Number(r.temperature) || 0,
-      differentialPressure: Number(r.differentialPressure) || 0,
-      calciumHardness: Number(r.calciumHardness) || 0,
-      cyanuricAcid: Number(r.cyanuricAcid) || 0,
+      chlorine: num(r.chlorine),
+      ph: num(r.ph),
+      alkalinity: num(r.alkalinity),
+      temperature: num(r.temperature),
+      differentialPressure: num(r.differentialPressure),
+      calciumHardness: num(r.calciumHardness),
+      cyanuricAcid: num(r.cyanuricAcid),
       formattedDate: format(r.timestamp, 'MMM d, HH:mm'),
     }));
 

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -26,10 +26,10 @@ interface DayStatus {
 
 interface TrendPoint {
   d: string;
-  chlorine: number;
-  ph: number;
-  alk: number;
-  press: number;
+  chlorine: number | null;
+  ph: number | null;
+  alk: number | null;
+  press: number | null;
 }
 
 interface Advisory {
@@ -78,7 +78,7 @@ interface ReportData {
   status: {
     overall: 'good' | 'watch' | 'warning' | 'critical';
     headline: string;
-    lsi: number;
+    lsi: number | null;
     lsiLabel: string;
     uptime: number;
     readings: number;
@@ -195,6 +195,7 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
     dayR.forEach(r => {
       METRICS.forEach(m => {
         const v = m.get(r);
+        if (v == null) return;
         const [lo, hi] = m.target;
         if (v < lo * 0.8 || v > hi * 1.2)      { worst = 'critical'; notes.push(`${m.label} critical`); }
         else if (v < lo * 0.9 || v > hi * 1.1)  { if (worst !== 'critical') worst = 'warning'; notes.push(`${m.label} off`); }
@@ -219,13 +220,13 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
   // Use the latest in-window reading for LSI; fall back to global latest only for the gauge snapshot
   const latestWeekR = weekReadings.length > 0 ? weekReadings[weekReadings.length - 1] : null;
   const latestR = latestWeekR ?? readings[0] ?? null;
-  const lsi = latestWeekR ? calculateLSI(latestWeekR) : 0;
-  const lsiAbs = Math.abs(lsi);
-  const lsiLabel = lsiAbs > 0.3 ? 'Critical' : lsiAbs > 0.1 ? 'Drifting' : 'Balanced';
+  const lsi: number | null = latestWeekR ? calculateLSI(latestWeekR) : null;
+  const lsiAbs = lsi == null ? null : Math.abs(lsi);
+  const lsiLabel = lsiAbs == null ? 'Insufficient data' : lsiAbs > 0.3 ? 'Critical' : lsiAbs > 0.1 ? 'Drifting' : 'Balanced';
 
   const allUnknown = weekReadings.length === 0;
-  const hasCritical = !allUnknown && (telemetry.some(m => m.status === 'critical') || lsiAbs > 0.3);
-  const hasWarning  = !allUnknown && (telemetry.some(m => m.status === 'warning')  || (lsiAbs > 0.1 && lsiAbs <= 0.3));
+  const hasCritical = !allUnknown && (telemetry.some(m => m.status === 'critical') || (lsiAbs != null && lsiAbs > 0.3));
+  const hasWarning  = !allUnknown && (telemetry.some(m => m.status === 'warning')  || (lsiAbs != null && lsiAbs > 0.1 && lsiAbs <= 0.3));
   const hasWatch    = !allUnknown && telemetry.some(m => m.status === 'watch');
   const overall: ReportData['status']['overall'] =
     allUnknown    ? 'watch' :
@@ -265,7 +266,7 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
   }
   if (weekReadings.length > 0) {
     advisories.push({ tier: 'good', title: 'Monitoring active', time: 'Week',
-      msg: `${weekReadings.length} reading${weekReadings.length !== 1 ? 's' : ''} recorded this week. LSI: ${lsi >= 0 ? '+' : ''}${lsi} (${lsiLabel}).`,
+      msg: `${weekReadings.length} reading${weekReadings.length !== 1 ? 's' : ''} recorded this week. LSI: ${lsi == null ? '—' : `${lsi >= 0 ? '+' : ''}${lsi}`} (${lsiLabel}).`,
       action: 'Continue current monitoring cadence.' });
   } else {
     advisories.push({ tier: 'watch', title: 'No data this period', time: 'Week',
@@ -321,9 +322,9 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
       timestamp: latestR ? `${fmtDate(latestR.timestamp)} · ${latestR.timestamp.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}` : 'No data',
       operator: operatorName,
       gauges: {
-        pressure: latestR ? `${latestR.differentialPressure} kPa` : '— kPa',
-        chlorine: latestR ? `${latestR.chlorine} ppm` : '— ppm',
-        ph: latestR ? `${latestR.ph}` : '—',
+        pressure: latestR?.differentialPressure != null ? `${latestR.differentialPressure} kPa` : '— kPa',
+        chlorine: latestR?.chlorine != null ? `${latestR.chlorine} ppm` : '— ppm',
+        ph: latestR?.ph != null ? `${latestR.ph}` : '—',
       },
     },
   };
@@ -331,9 +332,10 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
 
 // ── Visualization components ──────────────────────────────────────────────────
 
-function LsiGauge({ value = 0, size = 220, theme = 'dark' }: { value?: number; size?: number; theme?: 'dark' | 'light' }) {
+function LsiGauge({ value, size = 220, theme = 'dark' }: { value: number | null; size?: number; theme?: 'dark' | 'light' }) {
   const min = -0.5, max = 0.5;
-  const v = Math.max(min, Math.min(max, value));
+  const hasValue = value != null;
+  const v = hasValue ? Math.max(min, Math.min(max, value)) : 0;
   const pct = (v - min) / (max - min);
   const angle = -90 + pct * 180;
   const r = size * 0.42;
@@ -375,11 +377,11 @@ function LsiGauge({ value = 0, size = 220, theme = 'dark' }: { value?: number; s
           </g>
         );
       })}
-      <line x1={cx} y1={cy} x2={nx} y2={ny} stroke={ink} strokeWidth="3" strokeLinecap="round" />
+      {hasValue && <line x1={cx} y1={cy} x2={nx} y2={ny} stroke={ink} strokeWidth="3" strokeLinecap="round" />}
       <circle cx={cx} cy={cy} r="6" fill={ink} />
-      <circle cx={cx} cy={cy} r="3" fill={accent} />
-      <text x={cx} y={cy + 30} textAnchor="middle" fontSize="32" fontWeight="700" fontFamily="Space Mono, monospace" fill={ink}>{v >= 0 ? `+${v.toFixed(2)}` : v.toFixed(2)}</text>
-      <text x={cx} y={cy + 50} textAnchor="middle" fontSize="10" fontWeight="700" letterSpacing="0.16em" fill={accent} style={{ textTransform: 'uppercase' }}>{lsiLabel}</text>
+      {hasValue && <circle cx={cx} cy={cy} r="3" fill={accent} />}
+      <text x={cx} y={cy + 30} textAnchor="middle" fontSize="32" fontWeight="700" fontFamily="Space Mono, monospace" fill={ink}>{!hasValue ? '—' : v >= 0 ? `+${v.toFixed(2)}` : v.toFixed(2)}</text>
+      <text x={cx} y={cy + 50} textAnchor="middle" fontSize="10" fontWeight="700" letterSpacing="0.16em" fill={accent} style={{ textTransform: 'uppercase' }}>{!hasValue ? 'No data' : lsiLabel}</text>
     </svg>
   );
 }
@@ -771,7 +773,7 @@ function ReportA({ d }: { d: ReportData }) {
         </div>
         <div style={{ color: '#fff', fontSize: 14, lineHeight: 1.5, maxWidth: 540 }}>{d.status.headline}</div>
         <div style={{ display: 'flex', gap: 24 }}>
-          {[{ l: 'Uptime', v: `${d.status.uptime}%` }, { l: 'Readings', v: d.status.readings }, { l: 'LSI', v: d.status.lsi >= 0 ? `+${d.status.lsi}` : d.status.lsi }].map(s => (
+          {[{ l: 'Uptime', v: `${d.status.uptime}%` }, { l: 'Readings', v: d.status.readings }, { l: 'LSI', v: d.status.lsi == null ? '—' : d.status.lsi >= 0 ? `+${d.status.lsi}` : d.status.lsi }].map(s => (
             <div key={s.l} style={{ textAlign: 'right' }}>
               <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '.2em', textTransform: 'uppercase', color: '#4A6A80' }}>{s.l}</div>
               <div style={{ fontSize: 18, fontFamily: '"Space Mono",monospace', fontWeight: 700, color: '#4FC3F7', marginTop: 2 }}>{s.v}</div>
@@ -882,7 +884,7 @@ function ReportB({ d }: { d: ReportData }) {
         <div>
           <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.2em', textTransform: 'uppercase', color: '#7d8aa3', marginBottom: 14 }}>Headline</div>
           <p style={{ fontSize: 24, lineHeight: 1.3, fontWeight: 600, color: '#1a2740', margin: 0, letterSpacing: '-.01em' }}>"{d.status.headline}."</p>
-          <div style={{ marginTop: 18, fontSize: 12, color: '#7d8aa3', fontFamily: '"Space Mono",monospace', letterSpacing: '.08em' }}>{d.status.readings} readings · {d.status.uptime}% uptime · LSI {d.status.lsi >= 0 ? `+${d.status.lsi}` : d.status.lsi}</div>
+          <div style={{ marginTop: 18, fontSize: 12, color: '#7d8aa3', fontFamily: '"Space Mono",monospace', letterSpacing: '.08em' }}>{d.status.readings} readings · {d.status.uptime}% uptime · LSI {d.status.lsi == null ? '—' : d.status.lsi >= 0 ? `+${d.status.lsi}` : d.status.lsi}</div>
         </div>
         <div style={{ textAlign: 'right' }}>
           <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.2em', textTransform: 'uppercase', color: '#7d8aa3' }}>Saturation Index</div>
@@ -944,7 +946,7 @@ function ReportB({ d }: { d: ReportData }) {
         <p style={{ fontSize: 13, color: '#3a4a66', lineHeight: 1.7, margin: '18px 0 0', columnCount: 2, columnGap: 32 }}>
           {d.status.readings === 0
             ? 'No readings recorded for this week. Start logging readings to see trend analysis here.'
-            : `${d.status.readings} reading${d.status.readings !== 1 ? 's' : ''} recorded this week. LSI held at ${d.status.lsi >= 0 ? `+${d.status.lsi}` : d.status.lsi} (${d.status.lsiLabel}). ${d.status.overall === 'good' ? 'All parameters remained within spec for the full period.' : 'Some parameters required attention — see advisories above.'}`}
+            : `${d.status.readings} reading${d.status.readings !== 1 ? 's' : ''} recorded this week. LSI ${d.status.lsi == null ? 'not computable' : `held at ${d.status.lsi >= 0 ? `+${d.status.lsi}` : d.status.lsi}`} (${d.status.lsiLabel}). ${d.status.overall === 'good' ? 'All parameters remained within spec for the full period.' : 'Some parameters required attention — see advisories above.'}`}
         </p>
       </section>
 
@@ -989,7 +991,7 @@ function ReportC({ d }: { d: ReportData }) {
           </div>
           <div style={{ fontSize: 42, fontWeight: 800, marginTop: 18, lineHeight: 1.1, letterSpacing: '-.01em' }}>{d.status.headline}.</div>
           <div style={{ display: 'flex', gap: 28, marginTop: 28, flexWrap: 'wrap' }}>
-            {[{ l: 'Uptime', v: `${d.status.uptime}%` }, { l: 'Readings', v: d.status.readings }, { l: 'LSI', v: d.status.lsi >= 0 ? `+${d.status.lsi}` : d.status.lsi }, { l: 'Days OK', v: `${daysOK}/7` }].map(s => (
+            {[{ l: 'Uptime', v: `${d.status.uptime}%` }, { l: 'Readings', v: d.status.readings }, { l: 'LSI', v: d.status.lsi == null ? '—' : d.status.lsi >= 0 ? `+${d.status.lsi}` : d.status.lsi }, { l: 'Days OK', v: `${daysOK}/7` }].map(s => (
               <div key={s.l}>
                 <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: '.2em', textTransform: 'uppercase', color: '#4A6A80' }}>{s.l}</div>
                 <div style={{ fontSize: 28, fontFamily: '"Space Mono",monospace', fontWeight: 700, color: '#4FC3F7', marginTop: 2 }}>{s.v}</div>

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -191,17 +191,24 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
       return { date: fmtDate(d), status: 'unknown' as const, note: 'No readings' };
     }
     let worst: 'good' | 'watch' | 'warning' | 'critical' = 'good';
+    let observedAny = false;
     const notes: string[] = [];
     dayR.forEach(r => {
       METRICS.forEach(m => {
         const v = m.get(r);
         if (v == null) return;
+        observedAny = true;
         const [lo, hi] = m.target;
         if (v < lo * 0.8 || v > hi * 1.2)      { worst = 'critical'; notes.push(`${m.label} critical`); }
         else if (v < lo * 0.9 || v > hi * 1.1)  { if (worst !== 'critical') worst = 'warning'; notes.push(`${m.label} off`); }
         else if (v < lo || v > hi)               { if (worst === 'good') worst = 'watch'; notes.push(`${m.label} watch`); }
       });
     });
+    // Days that contain only all-null readings get an unknown status — they're a
+    // monitoring gap, not "all nominal" data.
+    if (!observedAny) {
+      return { date: fmtDate(d), status: 'unknown' as const, note: 'No measurements logged' };
+    }
     return {
       date: fmtDate(d),
       status: worst,
@@ -475,21 +482,34 @@ function TrendLines({ trend, metrics, theme = 'dark', height = 220 }: { trend: T
         return <text key={i} x={x} y={H - 8} fontSize="8" fontFamily="Space Mono, monospace" fill={dim} textAnchor="middle">{i % 2 === 0 ? t.d : ''}</text>;
       })}
       {metrics.map(m => {
-        const vals = trend.map(t => t[m.key] as number);
-        const vMin = Math.min(...vals), vRange = (Math.max(...vals) - vMin) || 1;
-        const pts = vals.map((v, i) => {
-          const x = padL + (trend.length > 1 ? (i / (trend.length - 1)) * innerW : innerW / 2);
-          const y = padT + innerH - ((v - vMin) / vRange) * innerH;
-          return `${x},${y}`;
-        }).join(' ');
+        // Skip null points so missing samples render as gaps in the polyline rather than
+        // collapsing to zero and distorting the y-axis range.
+        const allVals = trend.map(t => t[m.key]) as (number | null)[];
+        const numericVals = allVals.filter((v): v is number => v != null);
+        if (numericVals.length === 0) return <g key={m.key as string} />;
+        const vMin = Math.min(...numericVals);
+        const vRange = (Math.max(...numericVals) - vMin) || 1;
+        const xAt = (i: number) => padL + (trend.length > 1 ? (i / (trend.length - 1)) * innerW : innerW / 2);
+        const yAt = (v: number) => padT + innerH - ((v - vMin) / vRange) * innerH;
+        // Build contiguous segments of non-null values so the polyline breaks at gaps.
+        const segments: string[][] = [];
+        let current: string[] = [];
+        allVals.forEach((v, i) => {
+          if (v == null) {
+            if (current.length > 0) { segments.push(current); current = []; }
+          } else {
+            current.push(`${xAt(i)},${yAt(v)}`);
+          }
+        });
+        if (current.length > 0) segments.push(current);
         return (
           <g key={m.key as string}>
-            <polyline points={pts} fill="none" stroke={m.color} strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" />
-            {vals.map((v, i) => {
-              const x = padL + (trend.length > 1 ? (i / (trend.length - 1)) * innerW : innerW / 2);
-              const y = padT + innerH - ((v - vMin) / vRange) * innerH;
-              return <circle key={i} cx={x} cy={y} r="2" fill={m.color} />;
-            })}
+            {segments.map((pts, idx) => (
+              <polyline key={idx} points={pts.join(' ')} fill="none" stroke={m.color} strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" />
+            ))}
+            {allVals.map((v, i) => v == null ? null : (
+              <circle key={i} cx={xAt(i)} cy={yAt(v)} r="2" fill={m.color} />
+            ))}
           </g>
         );
       })}

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -234,6 +234,8 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
   // A week with reading documents but no actual measurements (every metric null)
   // is still a monitoring gap, not a healthy week — treat it the same as no readings.
   const allUnknown = weekReadings.length === 0 || telemetry.every(m => m.status === 'unknown');
+  const unknownMetrics = telemetry.filter(m => m.status === 'unknown').map(m => m.label.toLowerCase());
+  const hasUnmeasured = !allUnknown && unknownMetrics.length > 0;
   const hasCritical = !allUnknown && (telemetry.some(m => m.status === 'critical') || (lsiAbs != null && lsiAbs > 0.3));
   const hasWarning  = !allUnknown && (telemetry.some(m => m.status === 'warning')  || (lsiAbs != null && lsiAbs > 0.1 && lsiAbs <= 0.3));
   const hasWatch    = !allUnknown && telemetry.some(m => m.status === 'watch');
@@ -241,19 +243,23 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
     allUnknown    ? 'watch' :
     hasCritical   ? 'critical' :
     hasWarning    ? 'warning'  :
-    hasWatch      ? 'watch'    : 'good';
+    hasWatch      ? 'watch'    :
+    hasUnmeasured ? 'watch'    : 'good';
 
   // Only flag metrics that have actual data (exclude unknown placeholders)
   const badMetrics = telemetry.filter(m => m.status !== 'good' && m.status !== 'unknown').map(m => m.label.toLowerCase());
+  const fmtList = (xs: string[]) => xs.length <= 1 ? (xs[0] ?? '') : `${xs.slice(0, -1).join(', ')} and ${xs[xs.length - 1]}`;
   const headline = allUnknown
     ? (weekReadings.length === 0
         ? 'No readings recorded this week — monitoring gap'
         : 'Readings logged but no measurements recorded — monitoring gap')
     : badMetrics.length === 0
-    ? 'All parameters within specification this week'
+    ? (hasUnmeasured
+        ? `Measured parameters within specification — ${fmtList(unknownMetrics)} not measured this week`
+        : 'All parameters within specification this week')
     : badMetrics.length === 1
-    ? `${badMetrics[0]} requires attention this week`
-    : `${badMetrics.slice(0, -1).join(', ')} and ${badMetrics[badMetrics.length - 1]} need monitoring`;
+    ? `${badMetrics[0]} requires attention this week${hasUnmeasured ? ` (${fmtList(unknownMetrics)} not measured)` : ''}`
+    : `${fmtList(badMetrics)} need monitoring${hasUnmeasured ? ` (${fmtList(unknownMetrics)} not measured)` : ''}`;
 
   const advisories: Advisory[] = [];
   const pressM = telemetry.find(m => m.key === 'press');
@@ -275,14 +281,20 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
       msg: `FC dropped to ${clM.min} ppm — below target of ${DEFAULT_RANGES.chlorine.min} ppm.`,
       action: 'Check chlorine supply and dosing schedule.' });
   }
-  if (weekReadings.length > 0) {
+  if (allUnknown) {
+    advisories.push({ tier: 'watch', title: 'No data this period', time: 'Week',
+      msg: weekReadings.length === 0
+        ? 'No readings were recorded during this 7-day window.'
+        : `${weekReadings.length} reading${weekReadings.length !== 1 ? 's' : ''} logged but no measurements were recorded.`,
+      action: 'Verify data entry cadence and log a reading with measurements to resume monitoring.' });
+  } else if (hasUnmeasured) {
+    advisories.push({ tier: 'watch', title: 'Partial monitoring', time: 'Week',
+      msg: `${weekReadings.length} reading${weekReadings.length !== 1 ? 's' : ''} recorded, but ${fmtList(unknownMetrics)} ${unknownMetrics.length === 1 ? 'was' : 'were'} not measured. LSI: ${lsi == null ? '—' : `${lsi >= 0 ? '+' : ''}${lsi}`} (${lsiLabel}).`,
+      action: 'Capture the missing measurements at the next test to close the monitoring gap.' });
+  } else {
     advisories.push({ tier: 'good', title: 'Monitoring active', time: 'Week',
       msg: `${weekReadings.length} reading${weekReadings.length !== 1 ? 's' : ''} recorded this week. LSI: ${lsi == null ? '—' : `${lsi >= 0 ? '+' : ''}${lsi}`} (${lsiLabel}).`,
       action: 'Continue current monitoring cadence.' });
-  } else {
-    advisories.push({ tier: 'watch', title: 'No data this period', time: 'Week',
-      msg: 'No readings were recorded during this 7-day window.',
-      action: 'Verify data entry cadence and log a reading to resume monitoring.' });
   }
 
   const nextSteps: NextStep[] = [];

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -231,7 +231,9 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
   const lsiAbs = lsi == null ? null : Math.abs(lsi);
   const lsiLabel = lsiAbs == null ? 'Insufficient data' : lsiAbs > 0.3 ? 'Critical' : lsiAbs > 0.1 ? 'Drifting' : 'Balanced';
 
-  const allUnknown = weekReadings.length === 0;
+  // A week with reading documents but no actual measurements (every metric null)
+  // is still a monitoring gap, not a healthy week — treat it the same as no readings.
+  const allUnknown = weekReadings.length === 0 || telemetry.every(m => m.status === 'unknown');
   const hasCritical = !allUnknown && (telemetry.some(m => m.status === 'critical') || (lsiAbs != null && lsiAbs > 0.3));
   const hasWarning  = !allUnknown && (telemetry.some(m => m.status === 'warning')  || (lsiAbs != null && lsiAbs > 0.1 && lsiAbs <= 0.3));
   const hasWatch    = !allUnknown && telemetry.some(m => m.status === 'watch');
@@ -244,7 +246,9 @@ function deriveReportData(readings: Reading[], inventory: InventoryItem[], user:
   // Only flag metrics that have actual data (exclude unknown placeholders)
   const badMetrics = telemetry.filter(m => m.status !== 'good' && m.status !== 'unknown').map(m => m.label.toLowerCase());
   const headline = allUnknown
-    ? 'No readings recorded this week — monitoring gap'
+    ? (weekReadings.length === 0
+        ? 'No readings recorded this week — monitoring gap'
+        : 'Readings logged but no measurements recorded — monitoring gap')
     : badMetrics.length === 0
     ? 'All parameters within specification this week'
     : badMetrics.length === 1

--- a/src/lib/lsi.ts
+++ b/src/lib/lsi.ts
@@ -1,6 +1,17 @@
 import { Reading } from '../types';
 
-export function calculateLSI(reading: Reading): number {
+export function calculateLSI(reading: Reading): number | null {
+  // LSI requires pH, temperature, calcium hardness, and alkalinity. If any are
+  // missing (not measured), return null rather than fabricating a value.
+  if (
+    reading.ph == null ||
+    reading.temperature == null ||
+    reading.calciumHardness == null ||
+    reading.alkalinity == null
+  ) {
+    return null;
+  }
+
   const getTF = (temp: number) => {
     if (temp < 0) return 0;
     if (temp < 10) return 0.3;
@@ -34,10 +45,10 @@ export function calculateLSI(reading: Reading): number {
   };
 
   const lsi =
-    (Number(reading.ph) || 0) +
-    getTF(Number(reading.temperature) || 0) +
-    getCF(Number(reading.calciumHardness) || 0) +
-    getAF(Number(reading.alkalinity) || 0) -
+    reading.ph +
+    getTF(reading.temperature) +
+    getCF(reading.calciumHardness) +
+    getAF(reading.alkalinity) -
     12.1;
   return parseFloat(lsi.toFixed(2));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,13 +5,13 @@ export type TaskFrequency = 'daily' | 'weekly' | 'monthly' | 'once';
 export interface Reading {
   id: string;
   timestamp: Date;
-  chlorine: number;
-  ph: number;
-  alkalinity: number;
-  temperature: number;
-  differentialPressure: number;
-  calciumHardness: number;
-  cyanuricAcid: number;
+  chlorine: number | null;
+  ph: number | null;
+  alkalinity: number | null;
+  temperature: number | null;
+  differentialPressure: number | null;
+  calciumHardness: number | null;
+  cyanuricAcid: number | null;
   notes?: string;
   uid: string;
 }


### PR DESCRIPTION
## Summary
Replaces the silent-fallback model where untouched reading-form fields saved hardcoded estimates with a nullable schema where missing measurements are an explicit first-class state. Supersedes the carry-forward fallback from #20.

## Why
Even with #20's carry-forward logic, "not measured" was still being saved as a number — usually a copy of the previous reading. That polluted LSI calculations, trend charts, weekly averages, and AI prompts. With nullable fields, missing data is honestly recorded as missing, so:
- LSI returns `null` and the dashboard tile shows "—" / "Insufficient data" rather than fabricating a balanced score from zeros.
- Trend charts get gaps instead of plotting fake zeros that drag the line.
- Status alerts no longer fire spuriously (`null < n` was sneakily true via type coercion).
- AI prompts say "not measured" instead of feeding the model `0`.
- CSV exports emit empty cells instead of `0`.

## Changes
- **`src/types.ts`** — `Reading` numeric fields are now `number | null`.
- **`firestore.rules`** — each numeric field accepts null OR number; only `id`, `timestamp`, and `uid` are required. **Needs separate deploy:** `firebase deploy --only firestore:rules`.
- **`src/lib/lsi.ts`** — `calculateLSI` returns `number | null` and returns null when any required input (pH, temperature, calcium hardness, alkalinity) is missing.
- **`src/components/ReadingForm.tsx`** — removes `INITIAL_NUMERIC` defaults; every input starts empty; blank inputs stay null on blur; the submit warning banner is gone (null is a valid save state). Voice/image extraction still populates fields as before. Removes the `latestReading` prop and carry-forward logic.
- **`src/App.tsx`** — CSV export emits empty cells (not "0") for null values.
- **Dashboard / TrendCharts / History / WeeklyReport / GeminiAssistant** — render "—" / skip in alerts / leave gaps in charts / write "not measured" into AI prompts when a value is null.

## Backfill
No migration needed. `number | null` is a superset of `number` — old documents with all numeric fields continue to read fine; only future documents will contain nulls.

## Test plan
- [ ] Deploy Firestore rules first (`firebase deploy --only firestore:rules`) before merging the app, otherwise null writes will be rejected.
- [ ] Empty pool history → log a reading with only chlorine + pH → verify Firestore doc has 5 nulls; dashboard shows "—" for the missing five; LSI shows "—"; chart has gaps.
- [ ] Existing pool with history → log partial reading → same behavior, no carry-forward.
- [ ] Voice / image / edit flows still populate fields and save numeric values correctly.
- [ ] CSV export of a mixed-null reading produces empty cells, not `"0"`.
- [ ] `npm run lint` (passing locally).
- [ ] Manual UI testing in dev server (not yet performed).

https://claude.ai/code/session_016umL86wafiCDcKyibgszts

---
_Generated by [Claude Code](https://claude.ai/code/session_016umL86wafiCDcKyibgszts)_