### PR TITLE
Add confirmation prompts before delete actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -359,6 +359,10 @@ export default function App() {
   };
 
   const handleDeleteReading = async (id: string) => {
+    if (!window.confirm('Delete this reading permanently?')) {
+      toast.info('Reading deletion canceled');
+      return;
+    }
     try {
       await deleteDoc(doc(db, 'readings', id));
       markSaved('Reading deleted');
@@ -461,6 +465,10 @@ export default function App() {
   };
 
   const handleDeleteInventory = async (id: string) => {
+    if (!window.confirm('Remove this inventory item?')) {
+      toast.info('Inventory removal canceled');
+      return;
+    }
     try {
       await deleteDoc(doc(db, 'inventory', id));
       markSaved('Inventory item removed');
@@ -471,6 +479,10 @@ export default function App() {
   };
 
   const handleDeleteEquipment = async (id: string) => {
+    if (!window.confirm('Remove this equipment record?')) {
+      toast.info('Equipment removal canceled');
+      return;
+    }
     try {
       await deleteDoc(doc(db, 'equipment', id));
       markSaved('Equipment removed');
@@ -513,6 +525,10 @@ export default function App() {
   };
 
   const handleDeleteWishlist = async (id: string) => {
+    if (!window.confirm('Remove this wishlist item?')) {
+      toast.info('Wishlist removal canceled');
+      return;
+    }
     try {
       await deleteDoc(doc(db, 'wishlist', id));
       markSaved('Wishlist item removed');


### PR DESCRIPTION
### Motivation
- Prevent accidental destructive actions by requiring explicit confirmation before deleting records.
- Provide clear feedback when a user cancels a destructive action so the UI communicates the result.

### Description
- Added confirmation dialogs to delete handlers for readings, inventory items, equipment, and wishlist entries in `src/App.tsx` using `window.confirm`.
- Show an informational toast via `toast.info(...)` when the user cancels a confirmation instead of silently returning.
- Preserved existing success toasts (`markSaved(...)`) and error handling for confirmed delete operations.
- Changes are limited to the delete flows and do not alter database or other non-destructive behavior.

### Testing
- Ran the project type-checking/lint step with `npm run lint` (which runs `tsc --noEmit`) and it completed successfully.
- No additional automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdf2c6d14832ea26b82d542a5b3f8)