### PR TITLE
Allow amending an existing log reading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -370,6 +370,7 @@ export default function App() {
     try {
       await updateDoc(doc(db, 'readings', id), {
         chlorine: updates.chlorine,
+        sanitisationMv: updates.sanitisationMv ?? null,
         ph: updates.ph,
         alkalinity: updates.alkalinity,
         temperature: updates.temperature,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ export default function App() {
   });
 
   const [isLogging, setIsLogging] = useState(false);
+  const [editingReading, setEditingReading] = useState<Reading | null>(null);
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [isCheatSheetOpen, setIsCheatSheetOpen] = useState(false);
   const [isGlossaryOpen, setIsGlossaryOpen] = useState(false);
@@ -342,6 +343,28 @@ export default function App() {
       setIsLogging(false);
     } catch (err) {
       handleFirestoreError(err, OperationType.WRITE, `readings/${id}`);
+    }
+  };
+
+  const handleUpdateReading = async (
+    id: string,
+    updates: Omit<Reading, 'id' | 'timestamp' | 'uid'>,
+  ) => {
+    if (!user) return;
+    try {
+      await updateDoc(doc(db, 'readings', id), {
+        chlorine: updates.chlorine,
+        ph: updates.ph,
+        alkalinity: updates.alkalinity,
+        temperature: updates.temperature,
+        differentialPressure: updates.differentialPressure,
+        calciumHardness: updates.calciumHardness,
+        cyanuricAcid: updates.cyanuricAcid,
+        notes: updates.notes ?? '',
+      });
+      setEditingReading(null);
+    } catch (err) {
+      handleFirestoreError(err, OperationType.UPDATE, `readings/${id}`);
     }
   };
 
@@ -721,12 +744,22 @@ export default function App() {
             onCancel={() => setIsLogging(false)}
           />
         )}
-        
+
+        {editingReading && (
+          <ReadingForm
+            key={editingReading.id}
+            initialReading={editingReading}
+            onSave={(updates) => handleUpdateReading(editingReading.id, updates)}
+            onCancel={() => setEditingReading(null)}
+          />
+        )}
+
         {isHistoryOpen && (
-          <History 
+          <History
             readings={readings}
             onBack={() => setIsHistoryOpen(false)}
             onDelete={handleDeleteReading}
+            onEdit={(reading) => setEditingReading(reading)}
           />
         )}
       </AnimatePresence>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -797,7 +797,10 @@ export default function App() {
             readings={readings}
             onBack={() => setIsHistoryOpen(false)}
             onDelete={handleDeleteReading}
-            onEdit={(reading) => setEditingReading(reading)}
+            onEdit={(reading) => {
+              setIsHistoryOpen(false);
+              setEditingReading(reading);
+            }}
           />
         )}
       </AnimatePresence>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -377,7 +377,9 @@ export default function App() {
         notes: updates.notes ?? '',
       });
       setEditingReading(null);
+      markSaved('Reading updated');
     } catch (err) {
+      toast.error('Could not update reading');
       handleFirestoreError(err, OperationType.UPDATE, `readings/${id}`);
     }
   };

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChevronLeft, Calendar, Clock, Droplets, Activity, Thermometer, TrendingUp, FileText, Trash2, Gauge, Waves, Sun } from 'lucide-react';
+import { ChevronLeft, Calendar, Clock, Droplets, Activity, Thermometer, TrendingUp, FileText, Trash2, Gauge, Waves, Sun, Pencil } from 'lucide-react';
 import { motion } from 'motion/react';
 import { Reading } from '../types';
 import { format } from 'date-fns';
@@ -8,9 +8,10 @@ interface Props {
   readings: Reading[];
   onBack: () => void;
   onDelete: (id: string) => void;
+  onEdit: (reading: Reading) => void;
 }
 
-export default function History({ readings, onBack, onDelete }: Props) {
+export default function History({ readings, onBack, onDelete, onEdit }: Props) {
 
   const uniqueVisitDays = new Set(readings.map((reading) => format(reading.timestamp, 'yyyy-MM-dd'))).size;
   const firstVisit = readings.length ? readings[readings.length - 1].timestamp : null;
@@ -84,8 +85,15 @@ export default function History({ readings, onBack, onDelete }: Props) {
                       </div>
                     )}
 
-                    <div className="flex justify-end border-t border-border-dim/30 pt-3 mt-1">
-                      <button 
+                    <div className="flex justify-end items-center gap-4 border-t border-border-dim/30 pt-3 mt-1">
+                      <button
+                        onClick={() => onEdit(reading)}
+                        className="flex items-center gap-2 text-[9px] font-bold uppercase tracking-widest text-ink-dim hover:text-accent transition-colors"
+                      >
+                        <Pencil size={12} />
+                        Amend Log
+                      </button>
+                      <button
                         onClick={() => onDelete(reading.id)}
                         className="flex items-center gap-2 text-[9px] font-bold uppercase tracking-widest text-critical/50 hover:text-critical transition-colors"
                       >

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -22,6 +22,7 @@ import { generateContentWithRetry } from '../lib/gemini';
 interface Props {
   onSave: (reading: Omit<Reading, 'id' | 'timestamp' | 'uid'>) => void;
   onCancel: () => void;
+  initialReading?: Reading;
 }
 
 const NUMERIC_FIELDS = ['chlorine', 'ph', 'alkalinity', 'temperature', 'differentialPressure', 'calciumHardness', 'cyanuricAcid'] as const;
@@ -52,9 +53,34 @@ const INITIAL_RAW: Record<NumericField, string> = {
   cyanuricAcid: '',
 };
 
-export default function ReadingForm({ onSave, onCancel }: Props) {
-  const [formData, setFormData] = useState<FormData>(INITIAL_FORM);
-  const [rawInputs, setRawInputs] = useState<Record<NumericField, string>>(INITIAL_RAW);
+export default function ReadingForm({ onSave, onCancel, initialReading }: Props) {
+  const isEditing = !!initialReading;
+  const [formData, setFormData] = useState<FormData>(() => {
+    if (!initialReading) return INITIAL_FORM;
+    return {
+      chlorine: initialReading.chlorine,
+      ph: initialReading.ph,
+      alkalinity: initialReading.alkalinity,
+      temperature: initialReading.temperature,
+      differentialPressure: initialReading.differentialPressure,
+      calciumHardness: initialReading.calciumHardness,
+      cyanuricAcid: initialReading.cyanuricAcid,
+      notes: initialReading.notes ?? '',
+    };
+  });
+  const [rawInputs, setRawInputs] = useState<Record<NumericField, string>>(() => {
+    if (!initialReading) return INITIAL_RAW;
+    const fromValue = (v: number | null) => (v == null ? '' : String(v));
+    return {
+      chlorine: fromValue(initialReading.chlorine),
+      ph: fromValue(initialReading.ph),
+      alkalinity: fromValue(initialReading.alkalinity),
+      temperature: fromValue(initialReading.temperature),
+      differentialPressure: fromValue(initialReading.differentialPressure),
+      calciumHardness: fromValue(initialReading.calciumHardness),
+      cyanuricAcid: fromValue(initialReading.cyanuricAcid),
+    };
+  });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [isTranscribingNotes, setIsTranscribingNotes] = useState(false);
@@ -291,8 +317,8 @@ missingInventory and missingEquipment should be arrays of strings when identifia
             Back to Dashboard
           </button>
           <div className="text-right">
-            <h1 className="text-lg font-bold text-ink tracking-tight">New Reading</h1>
-            <p className="text-[9px] font-bold uppercase tracking-widest text-ink-dim">Manual Data Entry</p>
+            <h1 className="text-lg font-bold text-ink tracking-tight">{isEditing ? 'Amend Reading' : 'New Reading'}</h1>
+            <p className="text-[9px] font-bold uppercase tracking-widest text-ink-dim">{isEditing ? 'Edit Existing Log' : 'Manual Data Entry'}</p>
           </div>
         </header>
 
@@ -371,7 +397,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
                 className="btn btn-primary w-full py-5 text-xs font-bold uppercase tracking-[0.2em] gap-3 shadow-2xl shadow-accent/20"
               >
                 <Save size={18} />
-                Commit to Database
+                {isEditing ? 'Save Changes' : 'Commit to Database'}
               </button>
             </div>
           </div>


### PR DESCRIPTION
Adds an "Amend Log" action on each entry in History that opens the
ReadingForm prefilled with the existing values. Saving updates the
reading in place without changing the timestamp or advancing the test
schedule.

https://claude.ai/code/session_01KF3DUPPyqiHPj55ppQwxJh