### PR TITLE
Add Sanitisation/ORP (sanitisationMv) with soft-warning validation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ export default function App() {
     const unsubReadings = onSnapshot(readingsQuery, (snapshot) => {
       setReadings(snapshot.docs.map(doc => ({
         ...doc.data(),
+        sanitisationMv: doc.data().sanitisationMv ?? null,
         timestamp: (doc.data().timestamp as Timestamp).toDate()
       } as Reading)));
     }, (err) => handleFirestoreError(err, OperationType.LIST, 'readings'));
@@ -314,6 +315,7 @@ export default function App() {
     // test, so it shouldn't advance the schedule and suppress the next reminder.
     const hasMeasurement =
       newReading.chlorine != null ||
+      newReading.sanitisationMv != null ||
       newReading.ph != null ||
       newReading.alkalinity != null ||
       newReading.temperature != null ||

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, Calendar, Clock, Droplets, Activity, Thermometer, Trending
 import { motion } from 'motion/react';
 import { Reading } from '../types';
 import { format } from 'date-fns';
+import { getSoftWarning } from '../lib/readingValidation';
 
 interface Props {
   readings: Reading[];
@@ -67,8 +68,9 @@ export default function History({ readings, onBack, onDelete }: Props) {
 
                   {/* Data Grid */}
                   <div className="p-4 md:col-span-3 flex flex-col justify-between gap-4">
-                    <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-4">
+                    <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4">
                       <DataPoint label="Chlorine" value={reading.chlorine} unit="ppm" icon={<Droplets size={12} />} color="text-sky-400" />
+                      <DataPoint label="Sanitisation / ORP" value={reading.sanitisationMv ?? null} unit="mV" icon={<Droplets size={12} />} color="text-blue-300" warning={reading.sanitisationMv != null ? getSoftWarning('sanitisationMv', reading.sanitisationMv) : null} />
                       <DataPoint label="pH Level" value={reading.ph} unit="" icon={<Activity size={12} />} color="text-emerald-400" />
                       <DataPoint label="Alkalinity" value={reading.alkalinity} unit="ppm" icon={<TrendingUp size={12} />} color="text-amber-400" />
                       <DataPoint label="Temp" value={reading.temperature} unit="°C" icon={<Thermometer size={12} />} color="text-red-400" />
@@ -104,7 +106,7 @@ export default function History({ readings, onBack, onDelete }: Props) {
   );
 }
 
-function DataPoint({ label, value, unit, icon, color }: { label: string; value: number | null; unit: string; icon: React.ReactNode; color: string }) {
+function DataPoint({ label, value, unit, icon, color, warning }: { label: string; value: number | null; unit: string; icon: React.ReactNode; color: string; warning?: { message: string } | null }) {
   const isMissing = value == null;
   return (
     <div className="space-y-1">
@@ -118,6 +120,7 @@ function DataPoint({ label, value, unit, icon, color }: { label: string; value: 
         </span>
         <span className="text-[9px] text-ink-dim font-bold uppercase">{unit}</span>
       </div>
+      {warning && !isMissing ? <p className="text-[9px] text-amber-300 leading-tight">{warning.message}</p> : null}
     </div>
   );
 }

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -118,7 +118,9 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
         flushed[field] = null;
       } else {
         const parsed = parseFloat(raw);
-        if (!isNaN(parsed)) flushed[field] = parsed;
+        // Non-empty but non-parsable (e.g. a lone "-"): treat as null so
+        // a stale formData value is not silently saved.
+        flushed[field] = isNaN(parsed) ? null : parsed;
       }
     }
     // Block all-null submissions: every numeric field would be saved as "not
@@ -397,11 +399,26 @@ missingInventory and missingEquipment should be arrays of strings when identifia
   );
 }
 
-function InputField({ label, name, value, unit, icon, onChange, onBlur, error, min, max, step, isEmpty }: any) {
+interface InputFieldProps {
+  label: string;
+  name: NumericField;
+  value: string;
+  unit: string;
+  icon: React.ReactNode;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
+  error?: string;
+  min?: number;
+  max?: number;
+  step?: string;
+  isEmpty: boolean;
+}
+
+function InputField({ label, name, value, unit, icon, onChange, onBlur, error, min, max, step, isEmpty }: InputFieldProps) {
   const parsedValue = value === '' ? null : Number(value);
   const softWarning =
     parsedValue != null && Number.isFinite(parsedValue) && !error
-      ? getSoftWarning(name as NumericField, parsedValue)
+      ? getSoftWarning(name, parsedValue)
       : null;
   return (
     <div className="space-y-3">

--- a/src/components/ReadingForm.tsx
+++ b/src/components/ReadingForm.tsx
@@ -16,16 +16,17 @@ import {
   MinusCircle,
 } from 'lucide-react';
 import { motion } from 'motion/react';
-import { Reading, DEFAULT_RANGES } from '../types';
+import { Reading } from '../types';
 import { generateContentWithRetry } from '../lib/gemini';
+import { getHardValidationError, getSoftWarning, NUMERIC_READING_FIELDS, NumericReadingField } from '../lib/readingValidation';
 
 interface Props {
   onSave: (reading: Omit<Reading, 'id' | 'timestamp' | 'uid'>) => void;
   onCancel: () => void;
 }
 
-const NUMERIC_FIELDS = ['chlorine', 'ph', 'alkalinity', 'temperature', 'differentialPressure', 'calciumHardness', 'cyanuricAcid'] as const;
-type NumericField = typeof NUMERIC_FIELDS[number];
+const NUMERIC_FIELDS = NUMERIC_READING_FIELDS;
+type NumericField = NumericReadingField;
 
 type FormData = Record<NumericField, number | null> & {
   notes: string;
@@ -33,6 +34,7 @@ type FormData = Record<NumericField, number | null> & {
 
 const INITIAL_FORM: FormData = {
   chlorine: null,
+  sanitisationMv: null,
   ph: null,
   alkalinity: null,
   temperature: null,
@@ -44,6 +46,7 @@ const INITIAL_FORM: FormData = {
 
 const INITIAL_RAW: Record<NumericField, string> = {
   chlorine: '',
+  sanitisationMv: '',
   ph: '',
   alkalinity: '',
   temperature: '',
@@ -60,14 +63,6 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
   const [isTranscribingNotes, setIsTranscribingNotes] = useState(false);
   const [isAnalyzingImage, setIsAnalyzingImage] = useState(false);
 
-  const validate = (name: string, value: number) => {
-    const range = DEFAULT_RANGES[name as keyof typeof DEFAULT_RANGES];
-    if (value < range.min || value > range.max) {
-      return `Out of range (${range.min}-${range.max} ${range.unit})`;
-    }
-    return '';
-  };
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value, type } = e.target;
 
@@ -82,7 +77,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
         const parsed = parseFloat(value);
         if (!isNaN(parsed)) {
           setFormData(prev => ({ ...prev, [fieldName]: parsed }));
-          setErrors(prev => ({ ...prev, [fieldName]: validate(fieldName, parsed) }));
+          setErrors(prev => ({ ...prev, [fieldName]: getHardValidationError(fieldName, parsed) }));
         }
       }
     } else {
@@ -107,7 +102,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
     }
     setRawInputs(prev => ({ ...prev, [fieldName]: String(parsed) }));
     setFormData(prev => ({ ...prev, [fieldName]: parsed }));
-    setErrors(prev => ({ ...prev, [fieldName]: validate(fieldName, parsed) }));
+    setErrors(prev => ({ ...prev, [fieldName]: getHardValidationError(fieldName, parsed) }));
   };
 
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -131,6 +126,17 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
     const hasAnyMeasurement = NUMERIC_FIELDS.some(f => flushed[f] != null);
     if (!hasAnyMeasurement) {
       setSubmitError('Enter at least one measurement before saving.');
+      return;
+    }
+    const hardErrors: Record<string, string> = {};
+    for (const field of NUMERIC_FIELDS) {
+      if (flushed[field] == null) continue;
+      const err = getHardValidationError(field, flushed[field] as number);
+      if (err) hardErrors[field] = err;
+    }
+    setErrors(prev => ({ ...prev, ...hardErrors }));
+    if (Object.keys(hardErrors).length > 0) {
+      setSubmitError('Fix invalid values before saving.');
       return;
     }
     setSubmitError(null);
@@ -172,7 +178,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
               {
                 text: isNotes
                   ? "Transcribe the following pool maintenance observations or chemical additions. Return ONLY the transcribed text."
-                  : "Transcribe the following pool reading. Extract values for Chlorine, pH, Alkalinity, Temperature, Pressure, Calcium, and CYA if mentioned. Return ONLY a JSON object with these keys: chlorine, ph, alkalinity, temperature, differentialPressure, calciumHardness, cyanuricAcid, notes."
+                    : "Transcribe the following pool reading. Extract values for Chlorine, ORP sanitisation mV, pH, Alkalinity, Temperature, Pressure, Calcium, and CYA if mentioned. Return ONLY a JSON object with these keys: chlorine, sanitisationMv, ph, alkalinity, temperature, differentialPressure, calciumHardness, cyanuricAcid, notes."
               }
             ],
             config: {
@@ -240,7 +246,7 @@ export default function ReadingForm({ onSave, onCancel }: Props) {
           },
           {
             text: `Extract pool report details from this image. Return ONLY a JSON object with keys:
-chlorine, ph, alkalinity, temperature, differentialPressure, calciumHardness, cyanuricAcid, notes, missingInventory, missingEquipment.
+chlorine, sanitisationMv, ph, alkalinity, temperature, differentialPressure, calciumHardness, cyanuricAcid, notes, missingInventory, missingEquipment.
 missingInventory and missingEquipment should be arrays of strings when identifiable.`
           }
         ],
@@ -299,6 +305,7 @@ missingInventory and missingEquipment should be arrays of strings when identifia
         <form onSubmit={handleSubmit} noValidate className="space-y-10 pb-32">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             <InputField label="Free Chlorine" name="chlorine" value={rawInputs.chlorine} unit="ppm" icon={<Droplets size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.chlorine} min={0} max={10} step="any" isEmpty={rawInputs.chlorine === ''} />
+            <InputField label="Sanitisation / ORP (mV)" name="sanitisationMv" value={rawInputs.sanitisationMv} unit="mV" icon={<Droplets size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.sanitisationMv} min={0} max={1200} step="any" isEmpty={rawInputs.sanitisationMv === ''} />
             <InputField label="pH Level" name="ph" value={rawInputs.ph} unit="" icon={<Activity size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.ph} min={0} max={14} step="any" isEmpty={rawInputs.ph === ''} />
             <InputField label="Total Alkalinity" name="alkalinity" value={rawInputs.alkalinity} unit="ppm" icon={<TrendingUp size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.alkalinity} min={0} max={300} step="any" isEmpty={rawInputs.alkalinity === ''} />
             <InputField label="Temperature" name="temperature" value={rawInputs.temperature} unit="°C" icon={<Thermometer size={16} />} onChange={handleChange} onBlur={handleBlur} error={errors.temperature} min={0} max={50} step="any" isEmpty={rawInputs.temperature === ''} />
@@ -366,6 +373,15 @@ missingInventory and missingEquipment should be arrays of strings when identifia
                   <span className="text-xs text-critical">{submitError}</span>
                 </div>
               )}
+              {NUMERIC_FIELDS.some((field) => {
+                const v = formData[field];
+                return typeof v === 'number' && !getHardValidationError(field, v) && !!getSoftWarning(field, v);
+              }) && (
+                <div className="flex items-center gap-2 p-3 rounded-xl bg-amber-500/10 border border-amber-400/40">
+                  <AlertCircle size={14} className="text-amber-300 flex-shrink-0" />
+                  <span className="text-xs text-amber-200">One or more values are outside the normal operating range. Please double-check, but you can still save this reading.</span>
+                </div>
+              )}
               <button
                 type="submit"
                 className="btn btn-primary w-full py-5 text-xs font-bold uppercase tracking-[0.2em] gap-3 shadow-2xl shadow-accent/20"
@@ -382,6 +398,11 @@ missingInventory and missingEquipment should be arrays of strings when identifia
 }
 
 function InputField({ label, name, value, unit, icon, onChange, onBlur, error, min, max, step, isEmpty }: any) {
+  const parsedValue = value === '' ? null : Number(value);
+  const softWarning =
+    parsedValue != null && Number.isFinite(parsedValue) && !error
+      ? getSoftWarning(name as NumericField, parsedValue)
+      : null;
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -389,6 +410,10 @@ function InputField({ label, name, value, unit, icon, onChange, onBlur, error, m
         {error ? (
           <span className="text-[9px] font-bold text-critical uppercase tracking-widest flex items-center gap-1.5">
             <AlertCircle size={10} /> {error}
+          </span>
+        ) : softWarning ? (
+          <span className="text-[9px] font-bold text-amber-300 uppercase tracking-widest flex items-center gap-1.5">
+            <AlertCircle size={10} /> {softWarning.message}
           </span>
         ) : isEmpty ? (
           <span className="text-[9px] font-bold text-ink-dim uppercase tracking-widest flex items-center gap-1.5">

--- a/src/lib/readingValidation.ts
+++ b/src/lib/readingValidation.ts
@@ -1,0 +1,63 @@
+import { DEFAULT_RANGES, Reading } from '../types';
+
+export type SoftValidationLevel = 'warning' | 'elevated';
+
+export interface SoftValidationWarning {
+  field: keyof Pick<Reading, 'chlorine' | 'ph' | 'alkalinity' | 'temperature' | 'differentialPressure' | 'calciumHardness' | 'cyanuricAcid' | 'sanitisationMv'>;
+  message: string;
+  level: SoftValidationLevel;
+}
+
+export const NUMERIC_READING_FIELDS = [
+  'chlorine',
+  'ph',
+  'alkalinity',
+  'temperature',
+  'differentialPressure',
+  'calciumHardness',
+  'cyanuricAcid',
+  'sanitisationMv',
+] as const;
+
+export type NumericReadingField = typeof NUMERIC_READING_FIELDS[number];
+
+const HARD_MIN_BY_FIELD: Partial<Record<NumericReadingField, number>> = {
+  chlorine: 0,
+  ph: 0,
+  alkalinity: 0,
+  temperature: -50,
+  differentialPressure: 0,
+  calciumHardness: 0,
+  cyanuricAcid: 0,
+  sanitisationMv: 0,
+};
+
+export function getHardValidationError(field: NumericReadingField, value: number): string {
+  if (!Number.isFinite(value)) return 'Enter a valid number.';
+  const min = HARD_MIN_BY_FIELD[field];
+  if (typeof min === 'number' && value < min) {
+    return `${field === 'ph' ? 'pH' : 'Value'} cannot be negative.`;
+  }
+  return '';
+}
+
+export function getSoftWarning(field: NumericReadingField, value: number): SoftValidationWarning | null {
+  if (!Number.isFinite(value)) return null;
+  if (field === 'sanitisationMv') {
+    if (value < 650) return { field, level: 'warning', message: 'Sanitisation may be too low (<650 mV).' };
+    if (value > 850) return { field, level: 'warning', message: 'Sanitisation may be too high (>850 mV).' };
+    if (value >= 750) return { field, level: 'elevated', message: 'High ORP (750–850 mV), usually acceptable depending on context.' };
+    return null;
+  }
+
+  const range = DEFAULT_RANGES[field as keyof typeof DEFAULT_RANGES];
+  if (!range) return null;
+  if (value < range.min || value > range.max) {
+    return {
+      field,
+      level: 'warning',
+      message: 'This value is outside the normal operating range. Please double-check it, but you can still save the reading.',
+    };
+  }
+  return null;
+}

--- a/src/lib/readingValidation.ts
+++ b/src/lib/readingValidation.ts
@@ -32,11 +32,40 @@ const HARD_MIN_BY_FIELD: Partial<Record<NumericReadingField, number>> = {
   sanitisationMv: 0,
 };
 
+const HARD_MAX_BY_FIELD: Partial<Record<NumericReadingField, number>> = {
+  chlorine: 20,
+  ph: 14,
+  alkalinity: 2000,
+  temperature: 100,
+  differentialPressure: 10000,
+  calciumHardness: 10000,
+  cyanuricAcid: 1000,
+  sanitisationMv: 2000,
+};
+
+const FIELD_LABEL: Record<NumericReadingField, string> = {
+  chlorine: 'Chlorine',
+  ph: 'pH',
+  alkalinity: 'Alkalinity',
+  temperature: 'Temperature',
+  differentialPressure: 'Differential Pressure',
+  calciumHardness: 'Calcium Hardness',
+  cyanuricAcid: 'Cyanuric Acid',
+  sanitisationMv: 'ORP',
+};
+
 export function getHardValidationError(field: NumericReadingField, value: number): string {
   if (!Number.isFinite(value)) return 'Enter a valid number.';
+  const label = FIELD_LABEL[field];
   const min = HARD_MIN_BY_FIELD[field];
   if (typeof min === 'number' && value < min) {
-    return `${field === 'ph' ? 'pH' : 'Value'} cannot be negative.`;
+    return min === 0
+      ? `${label} cannot be negative.`
+      : `${label} must be at least ${min}.`;
+  }
+  const max = HARD_MAX_BY_FIELD[field];
+  if (typeof max === 'number' && value > max) {
+    return `${label} cannot exceed ${max}.`;
   }
   return '';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface Reading {
   id: string;
   timestamp: Date;
   chlorine: number | null;
+  sanitisationMv: number | null;
   ph: number | null;
   alkalinity: number | null;
   temperature: number | null;
@@ -122,6 +123,7 @@ export interface WorkSession {
 
 export interface Ranges {
   chlorine: { min: number; max: number; unit: string };
+  sanitisationMv: { min: number; max: number; unit: string };
   ph: { min: number; max: number; unit: string };
   alkalinity: { min: number; max: number; unit: string };
   temperature: { min: number; max: number; unit: string };
@@ -132,6 +134,7 @@ export interface Ranges {
 
 export const DEFAULT_RANGES: Ranges = {
   chlorine: { min: 1, max: 3, unit: 'ppm' },
+  sanitisationMv: { min: 650, max: 750, unit: 'mV' },
   ph: { min: 7.2, max: 7.8, unit: 'pH' },
   alkalinity: { min: 80, max: 120, unit: 'ppm' },
   temperature: { min: 24, max: 30, unit: '°C' },


### PR DESCRIPTION
### Motivation
- Capture sanitisation/ORP readings (mV) because low ORP contributed to a past algae bloom and users need clear advisory feedback without blocking saves.
- Replace monolithic range-blocking validation with a two-layer model so impossible inputs are prevented but out-of-range yet possible chemistry readings only produce warnings.

### Description
- Add a typed optional field `sanitisationMv` to the `Reading` model and include a default range entry in `DEFAULT_RANGES` (`650–750 mV` target) by updating `src/types.ts`.
- Introduce `src/lib/readingValidation.ts` that exposes `getHardValidationError`, `getSoftWarning`, and `NUMERIC_READING_FIELDS` to implement hard validation (blocks invalid/impossible values) and soft warnings (advisory only), with ORP thresholds (<650, 650–750, 750–850, >850) encoded.
- Update `src/components/ReadingForm.tsx` to add the `Sanitisation / ORP (mV)` input, wire hard validation on submit using `getHardValidationError`, show inline soft warnings using `getSoftWarning`, and display a non-blocking summary warning panel above the submit button while preserving save behavior for soft-warning cases.
- Update `src/components/History.tsx` to render the saved ORP value and surface advisory text when a saved reading’s ORP is outside expected ranges, and update `src/App.tsx` Firestore hydration/save logic to default missing `sanitisationMv` to `null` so older records remain compatible.
- Ensure AI transcription/image extraction prompts were updated to include `sanitisationMv` so voice/photo input can populate the new field.

### Testing
- Ran typecheck/linter with `npm run lint` (`tsc --noEmit`) which completed successfully.
- Ran the project test script `npm test` (which runs the linter) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089cf88654832ead3f00d16dd2ba46)