### PR TITLE
Add calendar-based telemetry log view with day drill-down

### DIFF
--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -75,9 +75,9 @@ export default function History({ readings, onBack, onDelete }: Props) {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
             <div className="lg:col-span-2 card bg-surface border-border-dim p-4 space-y-3">
               <div className="flex items-center justify-between">
-                <button onClick={() => setCalendarMonth(subMonths(calendarMonth, 1))} className="p-2 rounded border border-border-dim text-ink-dim"><ChevronLeft size={14} /></button>
+                <button aria-label="Previous month" onClick={() => setCalendarMonth(subMonths(calendarMonth, 1))} className="p-2 rounded border border-border-dim text-ink-dim"><ChevronLeft size={14} /></button>
                 <p className="text-sm font-bold text-white">{format(calendarMonth, 'MMMM yyyy')}</p>
-                <button onClick={() => setCalendarMonth(addMonths(calendarMonth, 1))} className="p-2 rounded border border-border-dim text-ink-dim"><ChevronRight size={14} /></button>
+                <button aria-label="Next month" onClick={() => setCalendarMonth(addMonths(calendarMonth, 1))} className="p-2 rounded border border-border-dim text-ink-dim"><ChevronRight size={14} /></button>
               </div>
               <div className="grid grid-cols-7 gap-2 text-center text-[10px] uppercase tracking-widest text-ink-dim">
                 {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map((d) => <div key={d}>{d}</div>)}

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { ChevronLeft, Calendar, Clock, Droplets, Activity, Thermometer, TrendingUp, FileText, Trash2, Gauge, Waves, Sun } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { ChevronLeft, Calendar, Clock, Droplets, Activity, Thermometer, TrendingUp, FileText, Trash2, Gauge, Waves, Sun, Grid3X3, List, ChevronRight, ImagePlus } from 'lucide-react';
 import { motion } from 'motion/react';
 import { Reading } from '../types';
-import { format } from 'date-fns';
+import { addDays, endOfMonth, format, isSameDay, isSameMonth, startOfMonth, startOfWeek, subMonths, addMonths } from 'date-fns';
 import { getSoftWarning } from '../lib/readingValidation';
 
 interface Props {
@@ -12,29 +12,55 @@ interface Props {
 }
 
 export default function History({ readings, onBack, onDelete }: Props) {
+  const [viewMode, setViewMode] = useState<'list' | 'calendar'>('calendar');
+  const [calendarMonth, setCalendarMonth] = useState(() => startOfMonth(new Date()));
+  const [selectedDay, setSelectedDay] = useState<Date | null>(readings[0]?.timestamp ?? null);
 
   const uniqueVisitDays = new Set(readings.map((reading) => format(reading.timestamp, 'yyyy-MM-dd'))).size;
   const firstVisit = readings.length ? readings[readings.length - 1].timestamp : null;
   const lastVisit = readings.length ? readings[0].timestamp : null;
+
+  const groupedByDay = useMemo(() => {
+    return readings.reduce<Record<string, Reading[]>>((acc, reading) => {
+      const dayKey = format(reading.timestamp, 'yyyy-MM-dd');
+      acc[dayKey] = acc[dayKey] ?? [];
+      acc[dayKey].push(reading);
+      return acc;
+    }, {});
+  }, [readings]);
+
+  const selectedDayReadings = selectedDay ? groupedByDay[format(selectedDay, 'yyyy-MM-dd')] ?? [] : [];
+
+  const calendarDays = useMemo(() => {
+    const monthStart = startOfMonth(calendarMonth);
+    const monthEnd = endOfMonth(calendarMonth);
+    const gridStart = startOfWeek(monthStart, { weekStartsOn: 1 });
+    const days: Date[] = [];
+    for (let i = 0; i < 42; i += 1) {
+      const current = addDays(gridStart, i);
+      if (current > monthEnd && current.getDay() === 1) break;
+      days.push(current);
+    }
+    return days;
+  }, [calendarMonth]);
+
   return (
-    <motion.div 
-      initial={{ opacity: 0, x: 20 }}
-      animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: 20 }}
-      className="fixed inset-0 z-50 bg-bg overflow-y-auto anim-fade-up"
-    >
-      <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
+    <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="fixed inset-0 z-50 bg-bg overflow-y-auto anim-fade-up">
+      <div className="max-w-6xl mx-auto px-4 py-8 space-y-8">
         <header className="flex items-center justify-between border-b border-border-dim pb-6">
-          <button 
-            onClick={onBack} 
-            className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest text-ink-dim hover:text-accent transition-colors"
-          >
-            <ChevronLeft size={16} />
-            Back to Dashboard
+          <button onClick={onBack} className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest text-ink-dim hover:text-accent transition-colors">
+            <ChevronLeft size={16} />Back to Dashboard
           </button>
-          <div className="text-right">
+          <div className="text-right space-y-2">
             <h1 className="text-lg font-bold text-ink tracking-tight">Telemetry Logs</h1>
-            <p className="text-[9px] font-bold uppercase tracking-widest text-ink-dim">Historical Data Archive</p>
+            <div className="flex items-center justify-end gap-2">
+              <button onClick={() => setViewMode('calendar')} className={`px-2.5 py-1.5 rounded border text-[10px] uppercase tracking-widest font-bold ${viewMode === 'calendar' ? 'border-accent text-accent' : 'border-border-dim text-ink-dim'}`}>
+                <Grid3X3 size={12} className="inline mr-1" />Calendar
+              </button>
+              <button onClick={() => setViewMode('list')} className={`px-2.5 py-1.5 rounded border text-[10px] uppercase tracking-widest font-bold ${viewMode === 'list' ? 'border-accent text-accent' : 'border-border-dim text-ink-dim'}`}>
+                <List size={12} className="inline mr-1" />List
+              </button>
+            </div>
           </div>
         </header>
 
@@ -44,63 +70,57 @@ export default function History({ readings, onBack, onDelete }: Props) {
           <div className="card bg-surface border-border-dim p-4"><p className="text-[10px] uppercase tracking-widest text-ink-dim">Range</p><p className="text-xs font-mono text-ink-muted">{firstVisit ? format(firstVisit, 'MMM d, yyyy') : '—'} → {lastVisit ? format(lastVisit, 'MMM d, yyyy') : '—'}</p></div>
         </div>
 
-        <div className="space-y-4">
-          {readings.length === 0 ? (
-            <div className="card bg-bg/40 border-border-dim p-12 text-center space-y-4">
-              <div className="text-4xl opacity-20">⬡</div>
-              <p className="text-sm font-bold uppercase tracking-widest text-ink-muted">No Logs Found</p>
-            </div>
-          ) : (
-            readings.map((reading) => (
-              <div key={reading.id} className="card anim-scan bg-surface border-border-dim p-0 overflow-hidden group">
-                <div className="grid grid-cols-1 md:grid-cols-4">
-                  {/* Date/Time Sidebar */}
-                  <div className="bg-bg p-4 flex flex-col justify-center border-r border-border-dim md:col-span-1">
-                    <div className="flex items-center gap-2 text-accent mb-1">
-                      <Calendar size={14} />
-                      <span className="text-xs font-bold font-mono">{format(reading.timestamp, 'MMM d, yyyy')}</span>
-                    </div>
-                    <div className="flex items-center gap-2 text-ink-dim">
-                      <Clock size={14} />
-                      <span className="text-[10px] font-bold font-mono uppercase tracking-widest">{format(reading.timestamp, 'HH:mm:ss')}</span>
-                    </div>
-                  </div>
-
-                  {/* Data Grid */}
-                  <div className="p-4 md:col-span-3 flex flex-col justify-between gap-4">
-                    <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4">
-                      <DataPoint label="Chlorine" value={reading.chlorine} unit="ppm" icon={<Droplets size={12} />} color="text-sky-400" />
-                      <DataPoint label="Sanitisation / ORP" value={reading.sanitisationMv ?? null} unit="mV" icon={<Droplets size={12} />} color="text-blue-300" warning={reading.sanitisationMv != null ? getSoftWarning('sanitisationMv', reading.sanitisationMv) : null} />
-                      <DataPoint label="pH Level" value={reading.ph} unit="" icon={<Activity size={12} />} color="text-emerald-400" />
-                      <DataPoint label="Alkalinity" value={reading.alkalinity} unit="ppm" icon={<TrendingUp size={12} />} color="text-amber-400" />
-                      <DataPoint label="Temp" value={reading.temperature} unit="°C" icon={<Thermometer size={12} />} color="text-red-400" />
-                      <DataPoint label="Pressure" value={reading.differentialPressure} unit="PSI" icon={<Gauge size={12} />} color="text-indigo-400" />
-                      <DataPoint label="Calcium" value={reading.calciumHardness} unit="ppm" icon={<Waves size={12} />} color="text-cyan-400" />
-                      <DataPoint label="CYA" value={reading.cyanuricAcid} unit="ppm" icon={<Sun size={12} />} color="text-yellow-400" />
-                    </div>
-
-                    {reading.notes && (
-                      <div className="flex gap-2 p-3 bg-bg/60 rounded-lg border border-border-dim/30">
-                        <FileText size={14} className="text-ink-dim shrink-0 mt-0.5" />
-                        <p className="text-[11px] text-ink-muted italic leading-relaxed">{reading.notes}</p>
-                      </div>
-                    )}
-
-                    <div className="flex justify-end border-t border-border-dim/30 pt-3 mt-1">
-                      <button 
-                        onClick={() => onDelete(reading.id)}
-                        className="flex items-center gap-2 text-[9px] font-bold uppercase tracking-widest text-critical/50 hover:text-critical transition-colors"
-                      >
-                        <Trash2 size={12} />
-                        Purge Record
-                      </button>
-                    </div>
-                  </div>
-                </div>
+        {viewMode === 'calendar' ? (
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            <div className="lg:col-span-2 card bg-surface border-border-dim p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <button onClick={() => setCalendarMonth(subMonths(calendarMonth, 1))} className="p-2 rounded border border-border-dim text-ink-dim"><ChevronLeft size={14} /></button>
+                <p className="text-sm font-bold text-white">{format(calendarMonth, 'MMMM yyyy')}</p>
+                <button onClick={() => setCalendarMonth(addMonths(calendarMonth, 1))} className="p-2 rounded border border-border-dim text-ink-dim"><ChevronRight size={14} /></button>
               </div>
-            ))
-          )}
-        </div>
+              <div className="grid grid-cols-7 gap-2 text-center text-[10px] uppercase tracking-widest text-ink-dim">
+                {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map((d) => <div key={d}>{d}</div>)}
+              </div>
+              <div className="grid grid-cols-7 gap-2">
+                {calendarDays.map((day) => {
+                  const dayKey = format(day, 'yyyy-MM-dd');
+                  const logs = groupedByDay[dayKey] ?? [];
+                  return (
+                    <button key={dayKey} onClick={() => setSelectedDay(day)} className={`min-h-16 rounded border p-2 text-left ${isSameMonth(day, calendarMonth) ? 'border-border-dim' : 'border-border-dim/40 opacity-50'} ${selectedDay && isSameDay(selectedDay, day) ? 'ring-1 ring-accent' : ''}`}>
+                      <div className="flex items-center justify-between"><span className="text-xs text-ink">{format(day, 'd')}</span>{logs.length > 0 ? <span className="text-[10px] text-accent font-bold">{logs.length}</span> : null}</div>
+                      {logs.length > 0 ? <p className="text-[9px] text-ink-dim mt-1">{logs.length} report{logs.length === 1 ? '' : 's'}</p> : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="card bg-surface border-border-dim p-4 space-y-3">
+              <h3 className="text-xs font-bold uppercase tracking-widest text-ink-dim">{selectedDay ? format(selectedDay, 'EEE, MMM d') : 'Pick a day'}</h3>
+              <p className="text-[11px] text-ink-muted">{selectedDayReadings.length} logs for this day. You can review each report, delete incorrect entries, and re-log corrected values.</p>
+              <button disabled className="w-full rounded-lg border border-border-dim p-2 text-xs text-ink-dim flex items-center justify-center gap-2"><ImagePlus size={13} />Bulk photo upload (coming soon)</button>
+              <div className="space-y-2 max-h-[24rem] overflow-y-auto pr-1">
+                {selectedDayReadings.map((reading) => (
+                  <div key={reading.id} className="rounded border border-border-dim p-2 space-y-1">
+                    <p className="text-[10px] text-ink-dim">{format(reading.timestamp, 'HH:mm:ss')}</p>
+                    <p className="text-xs text-ink">pH {reading.ph ?? '—'} • ORP {reading.sanitisationMv ?? '—'} mV • FC {reading.chlorine ?? '—'} ppm</p>
+                    {reading.notes ? <p className="text-[11px] text-ink-muted">{reading.notes}</p> : null}
+                  </div>
+                ))}
+                {selectedDayReadings.length === 0 ? <p className="text-xs text-ink-dim">No logs for this day yet.</p> : null}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {readings.length === 0 ? <div className="card bg-bg/40 border-border-dim p-12 text-center space-y-4"><div className="text-4xl opacity-20">⬡</div><p className="text-sm font-bold uppercase tracking-widest text-ink-muted">No Logs Found</p></div> : readings.map((reading) => (
+              <div key={reading.id} className="card anim-scan bg-surface border-border-dim p-0 overflow-hidden group"><div className="grid grid-cols-1 md:grid-cols-4"><div className="bg-bg p-4 flex flex-col justify-center border-r border-border-dim md:col-span-1"><div className="flex items-center gap-2 text-accent mb-1"><Calendar size={14} /><span className="text-xs font-bold font-mono">{format(reading.timestamp, 'MMM d, yyyy')}</span></div><div className="flex items-center gap-2 text-ink-dim"><Clock size={14} /><span className="text-[10px] font-bold font-mono uppercase tracking-widest">{format(reading.timestamp, 'HH:mm:ss')}</span></div></div>
+                <div className="p-4 md:col-span-3 flex flex-col justify-between gap-4"><div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4"><DataPoint label="Chlorine" value={reading.chlorine} unit="ppm" icon={<Droplets size={12} />} color="text-sky-400" /><DataPoint label="Sanitisation / ORP" value={reading.sanitisationMv ?? null} unit="mV" icon={<Droplets size={12} />} color="text-blue-300" warning={reading.sanitisationMv != null ? getSoftWarning('sanitisationMv', reading.sanitisationMv) : null} /><DataPoint label="pH Level" value={reading.ph} unit="" icon={<Activity size={12} />} color="text-emerald-400" /><DataPoint label="Alkalinity" value={reading.alkalinity} unit="ppm" icon={<TrendingUp size={12} />} color="text-amber-400" /><DataPoint label="Temp" value={reading.temperature} unit="°C" icon={<Thermometer size={12} />} color="text-red-400" /><DataPoint label="Pressure" value={reading.differentialPressure} unit="PSI" icon={<Gauge size={12} />} color="text-indigo-400" /><DataPoint label="Calcium" value={reading.calciumHardness} unit="ppm" icon={<Waves size={12} />} color="text-cyan-400" /><DataPoint label="CYA" value={reading.cyanuricAcid} unit="ppm" icon={<Sun size={12} />} color="text-yellow-400" /></div>
+                  {reading.notes && (<div className="flex gap-2 p-3 bg-bg/60 rounded-lg border border-border-dim/30"><FileText size={14} className="text-ink-dim shrink-0 mt-0.5" /><p className="text-[11px] text-ink-muted italic leading-relaxed">{reading.notes}</p></div>)}
+                  <div className="flex justify-end border-t border-border-dim/30 pt-3 mt-1"><button onClick={() => onDelete(reading.id)} className="flex items-center gap-2 text-[9px] font-bold uppercase tracking-widest text-critical/50 hover:text-critical transition-colors"><Trash2 size={12} />Purge Record</button></div>
+                </div></div></div>
+            ))}
+          </div>
+        )}
       </div>
     </motion.div>
   );
@@ -108,19 +128,5 @@ export default function History({ readings, onBack, onDelete }: Props) {
 
 function DataPoint({ label, value, unit, icon, color, warning }: { label: string; value: number | null; unit: string; icon: React.ReactNode; color: string; warning?: { message: string } | null }) {
   const isMissing = value == null;
-  return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-widest text-ink-dim">
-        {icon}
-        {label}
-      </div>
-      <div className="flex items-baseline gap-1">
-        <span className={`text-lg font-bold font-mono ${isMissing ? 'text-ink-dim' : color}`}>
-          {isMissing ? '—' : value.toFixed(label === 'pH Level' ? 1 : 0)}
-        </span>
-        <span className="text-[9px] text-ink-dim font-bold uppercase">{unit}</span>
-      </div>
-      {warning && !isMissing ? <p className="text-[9px] text-amber-300 leading-tight">{warning.message}</p> : null}
-    </div>
-  );
+  return <div className="space-y-1"><div className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-widest text-ink-dim">{icon}{label}</div><div className="flex items-baseline gap-1"><span className={`text-lg font-bold font-mono ${isMissing ? 'text-ink-dim' : color}`}>{isMissing ? '—' : value.toFixed(label === 'pH Level' ? 1 : 0)}</span><span className="text-[9px] text-ink-dim font-bold uppercase">{unit}</span></div>{warning && !isMissing ? <p className="text-[9px] text-amber-300 leading-tight">{warning.message}</p> : null}</div>;
 }

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -12,9 +12,10 @@ interface Props {
 }
 
 export default function History({ readings, onBack, onDelete }: Props) {
+  const initialSelectedDay = readings[0]?.timestamp ?? null;
   const [viewMode, setViewMode] = useState<'list' | 'calendar'>('calendar');
-  const [calendarMonth, setCalendarMonth] = useState(() => startOfMonth(new Date()));
-  const [selectedDay, setSelectedDay] = useState<Date | null>(readings[0]?.timestamp ?? null);
+  const [calendarMonth, setCalendarMonth] = useState(() => startOfMonth(initialSelectedDay ?? new Date()));
+  const [selectedDay, setSelectedDay] = useState<Date | null>(initialSelectedDay);
 
   const uniqueVisitDays = new Set(readings.map((reading) => format(reading.timestamp, 'yyyy-MM-dd'))).size;
   const firstVisit = readings.length ? readings[readings.length - 1].timestamp : null;


### PR DESCRIPTION
### Motivation
- Provide a calendar-first view so operators can quickly see which days have logs and how many entries exist per day. 
- Make it easy to drill down into a specific day to review, amend, or purge same-day readings without losing the existing detailed list view. 
- Stage a bulk-photo workflow by adding a safe placeholder CTA so photo-related UX can be introduced incrementally. 

### Description
- Replaced the single-mode history UI with a Calendar/List toggle and calendar-first default by updating `src/components/History.tsx`. 
- Added day grouping and a calendar grid using `date-fns` (`startOfMonth`, `startOfWeek`, `addDays`, `subMonths`, `addMonths`, `isSameDay`, `isSameMonth`) to render month navigation and per-day report counts. 
- Implemented a day drill-down panel that shows all readings for the selected day (time, pH, ORP, free chlorine, notes) while preserving the original detailed list view and delete flow. 
- Included a disabled “Bulk photo upload (coming soon)” button as a UX placeholder and did not change any chemistry validation or persistence logic. 

### Testing
- Ran the TypeScript lint/type check with `npm run lint` (which runs `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e406f27b8832eab28dd9cbe5cfee1)