### PR TITLE
Add audio briefing with text-to-speech narration to weekly reports

### DIFF
--- a/src/components/SpokenReportControls.tsx
+++ b/src/components/SpokenReportControls.tsx
@@ -19,7 +19,9 @@ export default function SpokenReportControls({ fullReportText, summaryReportText
   const activeTypeRef = useRef<NarrationType | null>(null);
 
   // Cancel any in-progress speech when the component unmounts (e.g. user navigates away)
-  useEffect(() => () => { window.speechSynthesis.cancel(); }, []);
+  useEffect(() => () => {
+    if (typeof window !== 'undefined' && 'speechSynthesis' in window) window.speechSynthesis.cancel();
+  }, []);
 
   const stopSpeech = useCallback(() => {
     window.speechSynthesis.cancel();

--- a/src/components/SpokenReportControls.tsx
+++ b/src/components/SpokenReportControls.tsx
@@ -139,7 +139,12 @@ export default function SpokenReportControls({ fullReportText, summaryReportText
                     width: 3,
                     height: h,
                     transformOrigin: 'bottom',
-                    animation: 'audio-bar 0.75s ease-in-out infinite',
+                    animation:
+                      typeof window !== 'undefined' &&
+                      typeof window.matchMedia === 'function' &&
+                      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+                        ? 'none'
+                        : 'audio-bar 0.75s ease-in-out infinite',
                     animationDelay: `${i * 0.09}s`,
                   }}
                 />

--- a/src/components/SpokenReportControls.tsx
+++ b/src/components/SpokenReportControls.tsx
@@ -1,0 +1,219 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { AlignLeft, FileText, Pause, Play, Square, Volume2 } from 'lucide-react';
+
+type NarrationType = 'full' | 'summary';
+
+interface Props {
+  fullReportText: string;
+  summaryReportText: string;
+}
+
+// Heights in px for the equaliser bars (purely visual variety)
+const BAR_HEIGHTS = [5, 9, 6, 12, 7, 10, 5, 8, 4];
+
+export default function SpokenReportControls({ fullReportText, summaryReportText }: Props) {
+  const [isPlaying, setIsPlaying]   = useState(false);
+  const [isPaused, setIsPaused]     = useState(false);
+  const [activeType, setActiveType] = useState<NarrationType | null>(null);
+  // Keep a stable ref so event callbacks always see the latest state
+  const activeTypeRef = useRef<NarrationType | null>(null);
+
+  // Cancel any in-progress speech when the component unmounts (e.g. user navigates away)
+  useEffect(() => () => { window.speechSynthesis.cancel(); }, []);
+
+  const stopSpeech = useCallback(() => {
+    window.speechSynthesis.cancel();
+    setIsPlaying(false);
+    setIsPaused(false);
+    setActiveType(null);
+    activeTypeRef.current = null;
+  }, []);
+
+  const speak = useCallback((type: NarrationType) => {
+    window.speechSynthesis.cancel();
+
+    const text = type === 'full' ? fullReportText : summaryReportText;
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.rate   = 0.88;
+    utterance.pitch  = 1.0;
+    utterance.volume = 1.0;
+
+    // Pick a natural-sounding English voice if available
+    const voices = window.speechSynthesis.getVoices();
+    const preferred =
+      voices.find(v =>
+        v.lang.startsWith('en') &&
+        (v.name.includes('Samantha') ||
+         v.name.includes('Daniel') ||
+         v.name.includes('Karen') ||
+         v.name.includes('Google US English') ||
+         v.name.includes('Google UK English Female') ||
+         v.name.includes('Alex'))
+      ) ??
+      voices.find(v => v.lang.startsWith('en')) ??
+      voices[0];
+
+    if (preferred) utterance.voice = preferred;
+
+    utterance.onstart = () => {
+      setIsPlaying(true);
+      setIsPaused(false);
+      setActiveType(type);
+      activeTypeRef.current = type;
+    };
+
+    utterance.onend = () => {
+      setIsPlaying(false);
+      setIsPaused(false);
+      setActiveType(null);
+      activeTypeRef.current = null;
+    };
+
+    // 'interrupted' is fired when cancel() is called — not a user-visible error
+    utterance.onerror = (e) => {
+      if (e.error !== 'interrupted' && e.error !== 'canceled') {
+        setIsPlaying(false);
+        setIsPaused(false);
+        setActiveType(null);
+        activeTypeRef.current = null;
+      }
+    };
+
+    window.speechSynthesis.speak(utterance);
+  }, [fullReportText, summaryReportText]);
+
+  const pause = useCallback(() => {
+    window.speechSynthesis.pause();
+    setIsPlaying(false);
+    setIsPaused(true);
+  }, []);
+
+  const resume = useCallback(() => {
+    window.speechSynthesis.resume();
+    setIsPlaying(true);
+    setIsPaused(false);
+  }, []);
+
+  const isActive = isPlaying || isPaused;
+
+  if (typeof window === 'undefined' || !('speechSynthesis' in window)) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-2xl bg-[#0D1F38] border border-[#1E3A5F] p-5 space-y-4 no-print">
+
+      {/* ── Section header ──────────────────────────────────────────────────── */}
+      <div className="flex items-start gap-3">
+        <div className="w-9 h-9 rounded-xl bg-accent/15 border border-accent/25 flex items-center justify-center flex-shrink-0">
+          <Volume2 size={16} className="text-accent" />
+        </div>
+        <div>
+          <h3 className="text-[11px] font-bold uppercase tracking-widest text-white mb-1">
+            Audio Briefing
+          </h3>
+          <p className="text-[10px] text-[#4A6A80] leading-relaxed">
+            Prefer to listen? Use the audio briefing controls below to hear either the full
+            maintenance report or a short summary.
+          </p>
+        </div>
+      </div>
+
+      {/* ── Now-playing indicator ────────────────────────────────────────────── */}
+      {isActive && (
+        <div className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-accent/10 border border-accent/25">
+          {isPlaying ? (
+            // Animated equaliser bars
+            <span
+              className="flex items-end gap-[2px]"
+              aria-hidden="true"
+              style={{ height: 14 }}
+            >
+              {BAR_HEIGHTS.map((h, i) => (
+                <span
+                  key={i}
+                  className="rounded-sm bg-accent"
+                  style={{
+                    width: 3,
+                    height: h,
+                    transformOrigin: 'bottom',
+                    animation: 'audio-bar 0.75s ease-in-out infinite',
+                    animationDelay: `${i * 0.09}s`,
+                  }}
+                />
+              ))}
+            </span>
+          ) : (
+            <span className="w-3 h-3 rounded-full bg-accent/40 border border-accent/60 flex-shrink-0" aria-hidden="true" />
+          )}
+          <span
+            className="text-[10px] font-bold text-accent uppercase tracking-widest"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {isPlaying
+              ? `Now reading: ${activeType === 'full' ? 'Full report' : 'Summary'}`
+              : `Paused · ${activeType === 'full' ? 'Full report' : 'Summary'}`}
+          </span>
+        </div>
+      )}
+
+      {/* ── Primary play buttons (always visible) ───────────────────────────── */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => speak('full')}
+          className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-accent text-primary font-bold text-[10px] uppercase tracking-widest hover:bg-accent/90 transition-all active:scale-95"
+          aria-label="Listen to full maintenance report"
+          aria-pressed={isPlaying && activeType === 'full'}
+        >
+          <FileText size={13} aria-hidden="true" />
+          Listen to full report
+        </button>
+
+        <button
+          onClick={() => speak('summary')}
+          className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-[#0A1628] border border-[#1E3A5F] text-[#8AB4CC] font-bold text-[10px] uppercase tracking-widest hover:text-white hover:border-accent/40 transition-all active:scale-95"
+          aria-label="Listen to summary report"
+          aria-pressed={isPlaying && activeType === 'summary'}
+        >
+          <AlignLeft size={13} aria-hidden="true" />
+          Listen to summary
+        </button>
+      </div>
+
+      {/* ── Transport controls (pause / resume / stop) ───────────────────────── */}
+      {isActive && (
+        <div className="flex flex-wrap gap-2">
+          {isPlaying ? (
+            <button
+              onClick={pause}
+              className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-amber-500/15 border border-amber-500/30 text-amber-400 font-bold text-[10px] uppercase tracking-widest hover:bg-amber-500/25 transition-all active:scale-95"
+              aria-label="Pause narration"
+            >
+              <Pause size={13} aria-hidden="true" />
+              Pause
+            </button>
+          ) : (
+            <button
+              onClick={resume}
+              className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-accent/15 border border-accent/30 text-accent font-bold text-[10px] uppercase tracking-widest hover:bg-accent/25 transition-all active:scale-95"
+              aria-label="Resume narration"
+            >
+              <Play size={13} aria-hidden="true" />
+              Resume
+            </button>
+          )}
+
+          <button
+            onClick={stopSpeech}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-red-500/10 border border-red-500/25 text-red-400 font-bold text-[10px] uppercase tracking-widest hover:bg-red-500/20 transition-all active:scale-95"
+            aria-label="Stop narration"
+          >
+            <Square size={13} fill="currentColor" aria-hidden="true" />
+            Stop
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -4,6 +4,7 @@ import { X, Printer, FileText } from 'lucide-react';
 import type { User } from 'firebase/auth';
 import { Reading, InventoryItem, DEFAULT_RANGES } from '../types';
 import { calculateLSI } from '../lib/lsi';
+import SpokenReportControls from './SpokenReportControls';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -1100,6 +1101,156 @@ function ReportC({ d }: { d: ReportData }) {
   );
 }
 
+// ── Narration text builder ────────────────────────────────────────────────────
+
+function buildNarration(d: ReportData): { full: string; summary: string } {
+  // ── Shared helpers ────────────────────────────────────────────────────────
+  const statusLabel = ({ good: 'Good', watch: 'Watch', warning: 'Action Required', critical: 'Critical' } as const)[d.status.overall];
+  const lsiVal = d.status.lsi;
+
+  const lsiNarr = lsiVal == null
+    ? 'The saturation index could not be calculated this period.'
+    : Math.abs(lsiVal) <= 0.1
+    ? 'The water is well-balanced.'
+    : lsiVal < -0.3
+    ? 'Water chemistry is notably corrosive. pH, alkalinity, or calcium hardness should be increased to restore balance.'
+    : lsiVal > 0.3
+    ? 'Water is significantly scale-forming. A reduction in pH or alkalinity is recommended.'
+    : lsiVal < 0
+    ? 'Water is slightly corrosive. Monitor and adjust as needed at the next service visit.'
+    : 'Water is slightly scale-forming. A small pH reduction is advisable.';
+
+  const measuredMetrics = d.telemetry.filter(m => m.status !== 'unknown' && !isNaN(m.avg));
+
+  const reorderItems = d.inventory.filter(i => i.action === 'REORDER');
+
+  // ── Full professional narration ───────────────────────────────────────────
+  const parts: string[] = [];
+
+  parts.push(
+    `This is your PoolStatus weekly maintenance briefing for ${d.facility.name}, covering ${d.facility.period}.`
+  );
+
+  parts.push(
+    `Overall pool status: ${statusLabel}. ${d.status.headline}. ` +
+    `This report is based on ${d.status.readings} reading${d.status.readings !== 1 ? 's' : ''} ` +
+    `recorded over the period, with ${d.status.uptime} percent monitoring uptime.`
+  );
+
+  parts.push(
+    lsiVal != null
+      ? `Water balance — the Langelier Saturation Index this week is ${lsiVal >= 0 ? 'plus' : 'minus'} ${Math.abs(lsiVal).toFixed(2)}, ` +
+        `rated as ${d.status.lsiLabel}. ${lsiNarr}`
+      : `Water balance — ${lsiNarr}`
+  );
+
+  if (measuredMetrics.length > 0) {
+    const metricLines = measuredMetrics.map(m => {
+      const unitStr = m.unit === '' ? '' : ` ${m.unit}`;
+      const statusDesc = ({
+        good:     'within the target range',
+        watch:    'slightly outside the target range and worth monitoring',
+        warning:  'outside the target range and requires attention',
+        critical: 'critically out of range and needs immediate correction',
+      } as const)[m.status];
+      return `${m.label}: ${m.avg}${unitStr}, ${statusDesc}.`;
+    });
+    parts.push(`Parameter summary. ${metricLines.join(' ')}`);
+  } else {
+    parts.push('No individual parameter data was recorded this week.');
+  }
+
+  if (d.advisories.length > 0) {
+    const advLines = d.advisories.map(a =>
+      a.tier === 'good'
+        ? a.msg
+        : `${a.title}. ${a.msg} Recommended action: ${a.action}`
+    );
+    parts.push(`Advisories. ${advLines.join(' ')}`);
+  }
+
+  if (d.nextSteps.length > 0) {
+    const stepLines = d.nextSteps.map(
+      n => `${n.title}: ${n.detail} This should be addressed ${n.due.toLowerCase()}.`
+    );
+    parts.push(`Recommended next steps. ${stepLines.join(' ')}`);
+  }
+
+  parts.push(
+    reorderItems.length > 0
+      ? `Inventory alert. ${reorderItems.map(i => i.name).join(' and ')} ` +
+        `${reorderItems.length === 1 ? 'is' : 'are'} below minimum stock and should be reordered before the next service.`
+      : 'Inventory. All chemical stocks are within acceptable levels.'
+  );
+
+  parts.push(
+    `That concludes this week's PoolStatus briefing. ` +
+    `Report ID ${d.facility.reportId}, generated ${d.facility.generatedAt}.`
+  );
+
+  const full = parts.join(' ');
+
+  // ── Short reassuring summary ──────────────────────────────────────────────
+  const summaryParts: string[] = [];
+
+  summaryParts.push(`Here is your brief pool maintenance summary for ${d.facility.period}.`);
+
+  const opening = ({
+    good:     'The pool is in good condition this week, with all monitored parameters within their target ranges.',
+    watch:    'The pool is generally stable this week, though a few items are worth keeping an eye on.',
+    warning:  'There are some parameters this week that require your attention before the next service visit.',
+    critical: 'There are critical water chemistry issues this week that need to be addressed promptly.',
+  } as const)[d.status.overall];
+  summaryParts.push(opening);
+
+  const chlorM  = d.telemetry.find(m => m.key === 'chlorine');
+  const phM2    = d.telemetry.find(m => m.key === 'ph');
+  const pressM2 = d.telemetry.find(m => m.key === 'press');
+
+  const keyVals = [
+    chlorM  && !isNaN(chlorM.avg)  ? `free chlorine at ${chlorM.avg} ppm`                 : null,
+    phM2    && !isNaN(phM2.avg)    ? `pH at ${phM2.avg}`                                   : null,
+    pressM2 && !isNaN(pressM2.avg) ? `filter pressure at ${pressM2.avg} kilopascals`       : null,
+  ].filter((v): v is string => v !== null);
+
+  if (keyVals.length > 0) {
+    summaryParts.push(`Key readings this week: ${keyVals.join(', ')}.`);
+  }
+
+  const topAdvisory =
+    d.advisories.find(a => a.tier === 'critical') ??
+    d.advisories.find(a => a.tier === 'warning')  ??
+    d.advisories.find(a => a.tier === 'watch');
+
+  if (topAdvisory && topAdvisory.tier !== 'good') {
+    summaryParts.push(`Main advisory: ${topAdvisory.title}. ${topAdvisory.action}`);
+  }
+
+  const topStep =
+    d.nextSteps.find(n => n.priority === 'high') ?? d.nextSteps[0];
+  if (topStep) {
+    summaryParts.push(`Priority action: ${topStep.title}. ${topStep.detail}`);
+  }
+
+  if (reorderItems.length > 0) {
+    summaryParts.push(
+      `Please reorder: ${reorderItems.map(i => i.name).join(' and ')}.`
+    );
+  }
+
+  const closing = ({
+    good:     'The pool has been left in a clear, balanced, and stable condition.',
+    watch:    'The pool is currently stable. Continue to monitor flagged parameters at the next service visit.',
+    warning:  'Please address the highlighted items at the next scheduled service.',
+    critical: 'Please contact your service technician to resolve the outstanding issues as soon as possible.',
+  } as const)[d.status.overall];
+  summaryParts.push(closing);
+
+  const summary = summaryParts.join(' ');
+
+  return { full, summary };
+}
+
 // ── Main WeeklyReport component ───────────────────────────────────────────────
 
 interface WeeklyReportProps {
@@ -1125,6 +1276,8 @@ export default function WeeklyReport({ isOpen, onClose, readings, inventory, use
     () => deriveReportData(readings, inventory, user),
     [readings, inventory, user],
   );
+
+  const narration = useMemo(() => buildNarration(data), [data]);
 
   return (
     <AnimatePresence>
@@ -1176,6 +1329,14 @@ export default function WeeklyReport({ isOpen, onClose, readings, inventory, use
                 <Printer size={16} />
               </button>
             </div>
+          </div>
+
+          {/* Audio briefing */}
+          <div className="max-w-[1180px] mx-auto mt-4 px-4">
+            <SpokenReportControls
+              fullReportText={narration.full}
+              summaryReportText={narration.summary}
+            />
           </div>
 
           {/* Report content */}

--- a/src/index.css
+++ b/src/index.css
@@ -144,6 +144,11 @@
   }
 }
 
+@keyframes audio-bar {
+  0%, 100% { transform: scaleY(0.35); opacity: 0.45; }
+  50%       { transform: scaleY(1);    opacity: 1; }
+}
+
 /* Custom scrollbar for better mobile feel */
 ::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Summary
Adds a new audio briefing feature to the weekly maintenance report modal, allowing users to listen to either a full professional narration or a concise summary of their pool maintenance status via the Web Speech API.

## Key Changes

- **New `SpokenReportControls` component** (`src/components/SpokenReportControls.tsx`)
  - Implements text-to-speech playback with play, pause, resume, and stop controls
  - Displays animated equaliser bars during playback and a now-playing indicator
  - Intelligently selects natural-sounding English voices (Samantha, Daniel, Karen, Google voices, Alex) with fallback to system default
  - Configures speech rate (0.88x) and handles lifecycle cleanup on unmount
  - Includes proper error handling for interrupted/canceled speech events
  - Fully accessible with ARIA labels and live regions

- **Narration text builder** (`src/components/WeeklyReport.tsx:buildNarration()`)
  - Generates two versions: a comprehensive full report and a brief reassuring summary
  - Full narration includes facility name, overall status, LSI analysis, parameter metrics, advisories, next steps, and inventory alerts
  - Summary focuses on opening status, key readings, top advisory, priority action, and closing guidance
  - Both versions are contextually aware of the report data and status tier

- **Integration into WeeklyReport modal**
  - Renders `SpokenReportControls` above the report content with full and summary narration text
  - Uses `useMemo` to avoid rebuilding narration on every render

- **Styling and animation** (`src/index.css`)
  - Added `audio-bar` keyframe animation for the equaliser bars during playback
  - Bars scale and fade in/out with staggered delays for visual variety

## Implementation Details

- Uses the native Web Speech API (`window.speechSynthesis`) with graceful degradation for unsupported browsers
- Maintains a stable ref (`activeTypeRef`) to ensure event callbacks always see the latest narration type state
- Cancels any in-progress speech when the component unmounts (e.g., user navigates away)
- Transport controls (pause/resume/stop) only appear when audio is actively playing or paused
- Styled to match the existing dark theme with accent colors and rounded corners
- Marked with `no-print` class to exclude from printed reports

https://claude.ai/code/session_01MGHZSu7sXAb9XTrZACDv6L